### PR TITLE
Remove dead code, trivial wrappers, and unused exports

### DIFF
--- a/src/livekit/wakeword/__init__.py
+++ b/src/livekit/wakeword/__init__.py
@@ -1,7 +1,23 @@
 """livekit-wakeword — Simplified pure-PyTorch wake word detection."""
 
-from .inference.listener import WakeWordListener
+from .config import WakeWordConfig, load_config
+from .data.augment import run_augment
+from .data.generate import run_generate
+from .export.onnx import run_export
+from .inference.listener import Detection, WakeWordListener
 from .inference.model import WakeWordModel
+from .training.trainer import run_train
 
 __version__ = "0.1.0"
-__all__ = ["WakeWordListener", "WakeWordModel", "__version__"]
+__all__ = [
+    "Detection",
+    "WakeWordConfig",
+    "WakeWordListener",
+    "WakeWordModel",
+    "load_config",
+    "run_augment",
+    "run_export",
+    "run_generate",
+    "run_train",
+    "__version__",
+]

--- a/src/livekit/wakeword/cli.py
+++ b/src/livekit/wakeword/cli.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import typer
 from rich.logging import RichHandler
 
+from .config import load_config
+
 app = typer.Typer(
     name="livekit-wakeword",
     help="Simplified pure-PyTorch wake word detection.",
@@ -22,12 +24,6 @@ logging.basicConfig(
 logger = logging.getLogger("livekit.wakeword")
 
 
-def _load_config(config_path: str) -> "WakeWordConfig":  # noqa: F821
-    from .config import load_config
-
-    return load_config(config_path)
-
-
 @app.command()
 def setup(
     data_dir: str = typer.Option("./data", help="Root data directory"),
@@ -36,8 +32,6 @@ def setup(
     ),
 ) -> None:
     """Download external dependencies: VITS TTS model, ACAV100M features, RIRs, backgrounds."""
-    from pathlib import Path
-
     data_path = Path(data_dir)
     data_path.mkdir(parents=True, exist_ok=True)
 
@@ -229,7 +223,7 @@ def generate(
     config_path: str = typer.Argument(..., help="Path to wake word config YAML"),
 ) -> None:
     """Generate synthetic speech clips (positive + adversarial negative)."""
-    config = _load_config(config_path)
+    config = load_config(config_path)
 
     logger.info(f"Generating data for '{config.model_name}'...")
     logger.info(f"Target phrases: {config.target_phrases}")
@@ -245,7 +239,7 @@ def augment(
     config_path: str = typer.Argument(..., help="Path to wake word config YAML"),
 ) -> None:
     """Augment clips and extract features through frozen pipeline."""
-    config = _load_config(config_path)
+    config = load_config(config_path)
 
     logger.info(f"Augmenting data for '{config.model_name}'...")
 
@@ -260,7 +254,7 @@ def train(
     config_path: str = typer.Argument(..., help="Path to wake word config YAML"),
 ) -> None:
     """Train classifier on extracted features (3-phase adaptive training)."""
-    config = _load_config(config_path)
+    config = load_config(config_path)
 
     logger.info(f"Training '{config.model_name}' model...")
     logger.info(f"Model: {config.model.model_type.value} ({config.model.model_size.value})")
@@ -278,7 +272,7 @@ def export(
     quantize: bool = typer.Option(False, "--quantize", help="Apply INT8 quantization"),
 ) -> None:
     """Export trained model to ONNX (optionally quantize for embedded)."""
-    config = _load_config(config_path)
+    config = load_config(config_path)
 
     logger.info(f"Exporting '{config.model_name}' to ONNX...")
 
@@ -293,7 +287,7 @@ def run(
     config_path: str = typer.Argument(..., help="Path to wake word config YAML"),
 ) -> None:
     """Run entire pipeline end-to-end: generate → augment → train → export."""
-    config = _load_config(config_path)
+    config = load_config(config_path)
 
     logger.info(f"Running full pipeline for '{config.model_name}'...")
 

--- a/src/livekit/wakeword/data/_piper_generate.py
+++ b/src/livekit/wakeword/data/_piper_generate.py
@@ -36,11 +36,6 @@ from ._vits_utils import audio_float_to_int16, generate_path, sequence_mask, sle
 logger = logging.getLogger(__name__)
 
 
-def _get_device() -> torch.device:
-    """Select the best available device."""
-    return get_device()
-
-
 def _to_device(tensor: torch.Tensor, device: torch.device) -> torch.Tensor:
     return tensor.to(device)
 
@@ -131,7 +126,7 @@ def generate_samples(
     # Validate espeak-ng is available before doing anything expensive
     _find_espeak_ng()
 
-    device = _get_device()
+    device = get_device()
 
     logger.debug("Loading VITS model from %s", model)
     model_path = Path(model)

--- a/src/livekit/wakeword/export/onnx.py
+++ b/src/livekit/wakeword/export/onnx.py
@@ -10,7 +10,6 @@ import torch
 
 from ..config import WakeWordConfig
 from ..models.pipeline import WakeWordClassifier
-from ..resources import get_embedding_model_path, get_mel_model_path
 
 logger = logging.getLogger(__name__)
 
@@ -57,44 +56,6 @@ def export_classifier(
 
     logger.info(f"Exported classifier ONNX to {output_path}")
     return output_path
-
-
-def export_full_pipeline(
-    config: WakeWordConfig,
-    model_path: Path,
-    output_path: Path,
-    opset_version: int = 18,
-) -> Path:
-    """Export classifier ONNX alongside the frozen mel/embedding ONNX models.
-
-    The full pipeline (waveform → score) cannot be a single ONNX graph because
-    the mel-spectrogram and speech-embedding stages are already separate ONNX
-    models (melspectrogram.onnx, embedding_model.onnx). This function exports
-    the classifier head and copies the frozen models into the output directory
-    so that all three ONNX files are co-located for deployment.
-
-    Output directory will contain:
-        - <model_name>.onnx (classifier: embeddings → score)
-        - melspectrogram.onnx (copy from data/models/)
-        - embedding_model.onnx (copy from data/models/)
-    """
-    import shutil
-
-    # Export the classifier head
-    classifier_path = export_classifier(config, model_path, output_path, opset_version)
-
-    # Copy frozen ONNX models alongside the classifier
-    out_dir = output_path.parent
-    for src in [get_mel_model_path(), get_embedding_model_path()]:
-        dst = out_dir / src.name
-        if src.exists() and src != dst:
-            shutil.copy2(src, dst)
-            logger.info(f"Copied {src.name} to {out_dir}")
-        elif not src.exists():
-            logger.warning(f"Bundled model not found: {src}")
-
-    logger.info(f"Exported full pipeline (3 ONNX files) to {out_dir}")
-    return classifier_path
 
 
 def quantize_onnx(input_path: Path, output_path: Path | None = None) -> Path:

--- a/src/livekit/wakeword/inference/model.py
+++ b/src/livekit/wakeword/inference/model.py
@@ -103,11 +103,6 @@ class WakeWordModel:
         self._last_scores[model_name] = 0.0
         logger.info(f"Loaded wake word model '{model_name}' from {model_path}")
 
-    @property
-    def model_names(self) -> list[str]:
-        """Return list of loaded model names."""
-        return list(self._classifiers.keys())
-
     def predict(self, audio_frame: np.ndarray) -> dict[str, float]:
         """Get wake word predictions for an audio frame.
 

--- a/src/livekit/wakeword/models/feature_extractor.py
+++ b/src/livekit/wakeword/models/feature_extractor.py
@@ -18,11 +18,6 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
-# Default ONNX model filenames (relative to data_dir/models/)
-MEL_ONNX_FILENAME = "melspectrogram.onnx"
-EMBEDDING_ONNX_FILENAME = "embedding_model.onnx"
-
-
 class MelSpectrogramFrontend:
     """Stage 1: Raw audio → mel-spectrogram features.
 
@@ -76,10 +71,6 @@ class MelSpectrogramFrontend:
         )
         self._amplitude_to_db = T.AmplitudeToDB(stype="power", top_db=80.0)
         logger.info("Using torchaudio mel fallback (close but not exact match to ONNX)")
-
-    @property
-    def uses_onnx(self) -> bool:
-        return self._onnx_session is not None
 
     def __call__(self, audio: np.ndarray) -> np.ndarray:
         """Compute mel spectrogram features.

--- a/src/livekit/wakeword/models/pipeline.py
+++ b/src/livekit/wakeword/models/pipeline.py
@@ -2,16 +2,11 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
-import numpy as np
 import torch
 import torch.nn as nn
 
 from ..config import WakeWordConfig
-from ..resources import get_embedding_model_path, get_mel_model_path
 from .classifier import build_classifier
-from .feature_extractor import MelSpectrogramFrontend, SpeechEmbedding
 
 
 class WakeWordClassifier(nn.Module):
@@ -30,67 +25,3 @@ class WakeWordClassifier(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.classifier(x)
-
-
-class WakeWordPipeline:
-    """Full pipeline: waveform → score.
-
-    Chains MelSpectrogramFrontend (ONNX) → SpeechEmbedding (ONNX) → Classifier (PyTorch).
-    Used for inference. Not an nn.Module since the first two stages are ONNX.
-    """
-
-    def __init__(self, config: WakeWordConfig):
-        self.mel_frontend = MelSpectrogramFrontend(
-            onnx_path=get_mel_model_path(),
-        )
-        self.speech_embedding = SpeechEmbedding(
-            onnx_path=get_embedding_model_path(),
-        )
-        self.classifier = build_classifier(
-            model_type=config.model.model_type,
-            model_size=config.model.model_size,
-        )
-        self.classifier.eval()
-
-    def load_classifier_weights(self, path: str | Path) -> None:
-        """Load trained classifier weights."""
-        state = torch.load(str(path), map_location="cpu", weights_only=True)
-        # Handle WakeWordClassifier wrapper (keys prefixed with 'classifier.')
-        self.classifier.load_state_dict(
-            {k.removeprefix("classifier."): v for k, v in state.items()}
-        )
-
-    @torch.no_grad()
-    def __call__(self, audio: np.ndarray) -> np.ndarray:
-        """Run full pipeline from raw audio to wake word score.
-
-        Args:
-            audio: (batch, samples) or (samples,) float32 raw 16kHz audio
-
-        Returns:
-            (batch, 1) confidence scores [0, 1]
-        """
-        if audio.ndim == 1:
-            audio = audio[np.newaxis, :]
-
-        # Stage 1: mel spectrogram (ONNX) → (batch, time_frames, 32)
-        mel = self.mel_frontend(audio)
-
-        # Stage 2: speech embedding (ONNX) → (batch, n_windows, 96)
-        embeddings = self.speech_embedding.extract_embeddings(mel)
-
-        # Take last 16 timesteps for classifier, pad if needed
-        n_windows = embeddings.shape[1]
-        if n_windows > 16:
-            embeddings = embeddings[:, -16:, :]
-        elif n_windows < 16:
-            pad = np.zeros(
-                (embeddings.shape[0], 16 - n_windows, 96),
-                dtype=np.float32,
-            )
-            embeddings = np.concatenate([pad, embeddings], axis=1)
-
-        # Stage 3: classifier (PyTorch) → (batch, 1)
-        emb_tensor = torch.from_numpy(embeddings)
-        scores = self.classifier(emb_tensor)
-        return scores.numpy()

--- a/tests/test_feature_extractor.py
+++ b/tests/test_feature_extractor.py
@@ -46,14 +46,9 @@ class TestMelSpectrogramFrontendFallback:
         mel2 = frontend(audio)
         np.testing.assert_allclose(mel1, mel2)
 
-    def test_uses_onnx_flag(self):
-        frontend = MelSpectrogramFrontend(onnx_path=None)
-        assert not frontend.uses_onnx
-
     def test_nonexistent_onnx_falls_back(self, tmp_path):
         """Non-existent ONNX path should fall back to torchaudio."""
         frontend = MelSpectrogramFrontend(onnx_path=tmp_path / "nonexistent.onnx")
-        assert not frontend.uses_onnx
         audio = np.random.randn(1, 16000).astype(np.float32)
         mel = frontend(audio)
         assert mel.shape[2] == 32


### PR DESCRIPTION
- Remove _load_config wrapper in cli.py, use load_config directly
- Remove _get_device wrapper in _piper_generate.py, use get_device directly
- Remove dead export_full_pipeline function from export/onnx.py
- Remove dead WakeWordPipeline class from models/pipeline.py
- Remove unused MEL_ONNX_FILENAME/EMBEDDING_ONNX_FILENAME constants
- Remove unused uses_onnx property and model_names property
- Remove duplicate `from pathlib import Path` in cli.py setup()
- Export Detection from top-level __init__.py