### PR TITLE
Hardcode 2.0s clip duration, remove compute_clip_duration()

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,10 +171,10 @@ config = WakeWordConfig(
 )
 
 # Run individual stages
-clip_duration = run_generate(config)       # TTS synthesis + adversarial negatives
-run_augment(config, clip_duration=clip_duration)  # Augment + feature extraction
-run_train(config)                          # 3-phase adaptive training
-run_export(config)                         # Export to ONNX
+run_generate(config)   # TTS synthesis + adversarial negatives
+run_augment(config)    # Augment + feature extraction
+run_train(config)      # 3-phase adaptive training
+run_export(config)     # Export to ONNX
 ```
 
 This is useful for integrating wake word training into larger pipelines, automating model iteration, or building custom tooling on top of the data generation and training stages.

--- a/docs/data-generation.md
+++ b/docs/data-generation.md
@@ -97,16 +97,6 @@ This ensures adversarial phrases sound close to the target but are distinct word
 
 Additional negative phrases can be specified via `custom_negative_phrases` in the config. These are appended to the auto-generated adversarial phrases before synthesis.
 
-## Clip Duration Calculation
-
-`compute_clip_duration()` determines the target audio window length for augmentation:
-
-1. Sample up to 50 WAV files from the positive training directory
-2. Compute the median duration
-3. Return `max(2.0, median_duration + 0.75)`
-
-The 750ms buffer ensures the wake word fits within the detection window with room for alignment jitter. The minimum of 2.0 seconds prevents windows that are too short.
-
 ## Output Directory Structure
 
 After generation, the output directory contains:

--- a/src/livekit/wakeword/cli.py
+++ b/src/livekit/wakeword/cli.py
@@ -297,10 +297,10 @@ def run(
     from .training.trainer import run_train
 
     logger.info("Step 1/4: Generate synthetic data")
-    clip_duration = run_generate(config)
+    run_generate(config)
 
     logger.info("Step 2/4: Augment + extract features")
-    run_augment(config, clip_duration=clip_duration)
+    run_augment(config)
 
     logger.info("Step 3/4: Train classifier")
     run_train(config)

--- a/src/livekit/wakeword/data/augment.py
+++ b/src/livekit/wakeword/data/augment.py
@@ -176,17 +176,12 @@ def align_clip_to_end(
     return result
 
 
-def run_augment(config: WakeWordConfig, clip_duration: float | None = None) -> None:
+def run_augment(config: WakeWordConfig) -> None:
     """Run augmentation pipeline on generated clips.
 
     Augments clips and then extracts features through the frozen pipeline.
-
-    Args:
-        config: Wake word configuration.
-        clip_duration: Target clip duration in seconds from generation phase.
-            Falls back to 2.0s if not provided.
     """
-    target_duration = clip_duration if clip_duration is not None else 2.0
+    target_duration = 2.0
 
     model_dir = config.model_output_dir
     augmentor = AudioAugmentor(

--- a/src/livekit/wakeword/data/generate.py
+++ b/src/livekit/wakeword/data/generate.py
@@ -232,30 +232,12 @@ def _write_silence(path: Path, duration_s: float = 1.0, sample_rate: int = 16000
     sf.write(str(path), samples, sample_rate)
 
 
-def compute_clip_duration(output_dir: Path, n_sample: int = 50) -> float:
-    """Sample clips and compute median duration + 750ms buffer, minimum 2.0s."""
-    import soundfile as sf
-
-    wav_files = sorted(output_dir.glob("*.wav"))[:n_sample]
-    if not wav_files:
-        return 2.0
-    durations = []
-    for f in wav_files:
-        info = sf.info(str(f))
-        durations.append(info.duration)
-    median = float(np.median(durations))
-    return max(2.0, median + 0.75)
-
-
-def run_generate(config: WakeWordConfig) -> float:
+def run_generate(config: WakeWordConfig) -> None:
     """Run the full generate pipeline for a wake word config.
 
     Supports resuming: counts existing ``clip_######.wav`` files in each split
     directory and skips completed splits or resumes partial ones from the
     existing count.
-
-    Returns:
-        Computed clip duration in seconds (median + 750ms buffer, min 2.0s).
     """
     model_dir = config.model_output_dir
     vits_model = config.data_path / "piper" / "en-us-libritts-high.pt"
@@ -353,8 +335,3 @@ def run_generate(config: WakeWordConfig) -> float:
                 **synth_kwargs,  # type: ignore[arg-type]
             )
 
-    # Compute dynamic clip duration
-    pos_dir = model_dir / "positive_train"
-    clip_duration = compute_clip_duration(pos_dir)
-    logger.info(f"Computed clip duration: {clip_duration:.2f}s")
-    return clip_duration


### PR DESCRIPTION
## Summary
- Remove `compute_clip_duration()` — the dynamic calculation (median + 750ms, min 2.0s) was unnecessary since the model always takes the last 16 embedding windows regardless of clip length, and the feature extractor already left-pads short clips
- Hardcode `target_duration = 2.0` in `run_augment()`
- Simplify `run_generate()` return type from `float` to `None` and remove `clip_duration` parameter plumbing through CLI and public API

## Test plan
- [x] `grep -r compute_clip_duration` returns no results
- [x] `grep -r clip_duration` returns no results in source files
- [x] All 38 tests pass (`pytest`)