### PR TITLE
Lazy-import run_export to avoid requiring onnx at import time

### DIFF
--- a/src/livekit/wakeword/__init__.py
+++ b/src/livekit/wakeword/__init__.py
@@ -3,12 +3,21 @@
 from .config import WakeWordConfig, load_config
 from .data.augment import run_augment
 from .data.generate import run_generate
-from .export.onnx import run_export
 from .inference.listener import Detection, WakeWordListener
 from .inference.model import WakeWordModel
 from .training.trainer import run_train
 
 __version__ = "0.1.0"
+
+
+def __getattr__(name: str) -> object:
+    if name == "run_export":
+        from .export.onnx import run_export
+
+        return run_export
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 __all__ = [
     "WakeWordConfig",
     "WakeWordListener",


### PR DESCRIPTION
## Summary
- Removed the eager `from .export.onnx import run_export` in `__init__.py` which pulled in `onnx` (an optional `[export]` extra) on every `import livekit.wakeword`
- Added a module-level `__getattr__` to lazily import `run_export` only when it's actually accessed
- `run_export` remains in `__all__` so it's still public API for `help()` and IDE autocomplete

## Test plan
- [ ] `pip install -e .` then `python -c "import livekit.wakeword; print('ok')"` succeeds without `onnx` installed
- [ ] `pip install -e ".[export]"` then `python -c "from livekit.wakeword import run_export; print(run_export)"` still works