### PR TITLE
Split run_augment into run_augment + run_extraction

### DIFF
--- a/docs/augmentation.md
+++ b/docs/augmentation.md
@@ -1,6 +1,6 @@
 # Augmentation Pipeline
 
-The augmentation stage applies realistic audio transformations to synthetic TTS clips, aligns them within detection windows, and extracts ONNX features into `.npy` files.
+The augmentation stage applies realistic audio transformations to synthetic TTS clips and aligns them within detection windows.
 
 **Source:** `src/livekit/wakeword/data/augment.py`
 **CLI:** `livekit-wakeword augment <config>`
@@ -22,9 +22,6 @@ Generated .wav clips
     ├──► Alignment
     │    Positive: end-of-window
     │    Negative: center-padded
-    │
-    └──► Feature extraction (ONNX)
-         Mel → embedding → .npy
 ```
 
 ## AudioAugmentor
@@ -113,22 +110,16 @@ For each WAV file in a directory:
 5. Align to window (end-aligned for positives, center-padded for negatives)
 6. Write back to the same file path
 
-## Feature Extraction
-
-After augmentation, `extract_features_for_config()` is called automatically to extract ONNX features from all four splits. See [Feature Extraction](feature-extraction.md) for details.
-
 ## Output
 
-After augmentation and feature extraction:
+After augmentation:
 
 ```
 output/<model_name>/
 ├── positive_train/                 # Augmented .wav files
 ├── positive_test/
 ├── negative_train/
-├── negative_test/
-├── positive_features_train.npy     # (N, 16, 96) float32
-├── positive_features_test.npy
-├── negative_features_train.npy
-└── negative_features_test.npy
+└── negative_test/
 ```
+
+Feature extraction is a separate step — see [Feature Extraction](feature-extraction.md).

--- a/docs/feature-extraction.md
+++ b/docs/feature-extraction.md
@@ -189,7 +189,7 @@ Left-padding places zeros at the **beginning** of the sequence, so the real audi
 
 ## Feature Extraction for Training
 
-`extract_features_for_config(config)` processes all four data splits:
+`run_extraction(config)` processes all four data splits:
 
 | Clip Directory    | Output File                   |
 | ----------------- | ----------------------------- |

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -78,6 +78,6 @@ src/livekit/wakeword/
 
 1. **[Data Generation](data-generation.md)** — Synthesize positive clips via VITS TTS with SLERP speaker blending + adversarial negatives
 2. **[Augmentation](augmentation.md)** — Apply pitch shift, EQ, RIR convolution, background mixing; align clips to training windows
-3. **[Feature Extraction](feature-extraction.md)** — Extract mel spectrograms and speech embeddings through frozen ONNX models
+3. **[Feature Extraction](feature-extraction.md)** — Extract mel spectrograms and speech embeddings through frozen ONNX models → `.npy` files
 4. **[Training](training.md)** — 3-phase adaptive training with hard example mining and checkpoint averaging
 5. **[Export & Inference](export-and-inference.md)** — Export classifier to ONNX and run real-time streaming detection

--- a/src/livekit/wakeword/__init__.py
+++ b/src/livekit/wakeword/__init__.py
@@ -2,6 +2,7 @@
 
 from .config import WakeWordConfig, load_config
 from .data.augment import run_augment
+from .data.features import run_extraction
 from .data.generate import run_generate
 from .inference.listener import Detection, WakeWordListener
 from .inference.model import WakeWordModel
@@ -26,6 +27,7 @@ __all__ = [
     "load_config",
     "run_augment",
     "run_export",
+    "run_extraction",
     "run_generate",
     "run_train",
     "__version__",

--- a/src/livekit/wakeword/cli.py
+++ b/src/livekit/wakeword/cli.py
@@ -244,9 +244,14 @@ def augment(
     logger.info(f"Augmenting data for '{config.model_name}'...")
 
     from .data.augment import run_augment
+    from .data.features import run_extraction
 
     run_augment(config)
-    logger.info("Augmentation + feature extraction complete!")
+    logger.info("Augmentation complete!")
+
+    logger.info("Extracting features through frozen embedding pipeline...")
+    run_extraction(config)
+    logger.info("Feature extraction complete!")
 
 
 @app.command()
@@ -292,20 +297,24 @@ def run(
     logger.info(f"Running full pipeline for '{config.model_name}'...")
 
     from .data.augment import run_augment
+    from .data.features import run_extraction
     from .data.generate import run_generate
     from .export.onnx import run_export
     from .training.trainer import run_train
 
-    logger.info("Step 1/4: Generate synthetic data")
+    logger.info("Step 1/5: Generate synthetic data")
     run_generate(config)
 
-    logger.info("Step 2/4: Augment + extract features")
+    logger.info("Step 2/5: Augment clips")
     run_augment(config)
 
-    logger.info("Step 3/4: Train classifier")
+    logger.info("Step 3/5: Extract features")
+    run_extraction(config)
+
+    logger.info("Step 4/5: Train classifier")
     run_train(config)
 
-    logger.info("Step 4/4: Export to ONNX")
+    logger.info("Step 5/5: Export to ONNX")
     run_export(config)
 
     logger.info("Full pipeline complete!")

--- a/src/livekit/wakeword/data/augment.py
+++ b/src/livekit/wakeword/data/augment.py
@@ -10,7 +10,6 @@ import numpy as np
 import torch
 
 from ..config import WakeWordConfig
-from .features import extract_features_for_config
 
 logger = logging.getLogger(__name__)
 
@@ -177,10 +176,7 @@ def align_clip_to_end(
 
 
 def run_augment(config: WakeWordConfig) -> None:
-    """Run augmentation pipeline on generated clips.
-
-    Augments clips and then extracts features through the frozen pipeline.
-    """
+    """Run augmentation pipeline on generated clips."""
     target_duration = config.augmentation.clip_duration
 
     model_dir = config.model_output_dir
@@ -203,10 +199,6 @@ def run_augment(config: WakeWordConfig) -> None:
                 round_idx=round_idx,
                 target_duration_s=target_duration,
             )
-
-    # Extract features through frozen pipeline
-    logger.info("Extracting features through frozen embedding pipeline...")
-    extract_features_for_config(config)
 
 
 def _augment_directory(

--- a/src/livekit/wakeword/data/features.py
+++ b/src/livekit/wakeword/data/features.py
@@ -69,7 +69,7 @@ def extract_features_from_directory(
     return np.stack(all_features, axis=0)  # (N_clips, 16, 96)
 
 
-def extract_features_for_config(config: WakeWordConfig) -> None:
+def run_extraction(config: WakeWordConfig) -> None:
     """Extract and save features for all splits of a wake word config."""
     mel_frontend = MelSpectrogramFrontend(
         onnx_path=get_mel_model_path(),


### PR DESCRIPTION
## Summary
- Decouple augmentation from feature extraction in `run_augment()` so the augmentation pipeline is reusable by downstream consumers with different feature frontends (e.g. raw mel for TFLite Micro on ESP32)
- Rename `extract_features_for_config` → `run_extraction` in `data/features.py`
- CLI `augment` and `run` commands now call `run_augment()` then `run_extraction()` explicitly (pipeline goes from 4 → 5 steps)
- Export `run_extraction` from `__init__.py`

## Test plan
- [x] `ruff check` passes on all changed files
- [x] All 38 tests pass