### PR TITLE
Expose public API through module __init__ files

### DIFF
--- a/src/livekit/wakeword/data/__init__.py
+++ b/src/livekit/wakeword/data/__init__.py
@@ -1,1 +1,21 @@
 """Data generation, augmentation, and dataset utilities."""
+
+from .augment import AudioAugmentor, align_clip_to_end, run_augment
+from .dataset import WakeWordDataset, create_dataloader, mmap_batch_generator
+from .features import N_EMBEDDING_TIMESTEPS, extract_features_from_directory, run_extraction
+from .generate import generate_adversarial_phrases, run_generate, synthesize_clips
+
+__all__ = [
+    "AudioAugmentor",
+    "N_EMBEDDING_TIMESTEPS",
+    "WakeWordDataset",
+    "align_clip_to_end",
+    "create_dataloader",
+    "extract_features_from_directory",
+    "generate_adversarial_phrases",
+    "mmap_batch_generator",
+    "run_augment",
+    "run_extraction",
+    "run_generate",
+    "synthesize_clips",
+]

--- a/src/livekit/wakeword/export/__init__.py
+++ b/src/livekit/wakeword/export/__init__.py
@@ -1,1 +1,9 @@
 """ONNX export and quantization."""
+
+from .onnx import export_classifier, quantize_onnx, run_export
+
+__all__ = [
+    "export_classifier",
+    "quantize_onnx",
+    "run_export",
+]

--- a/src/livekit/wakeword/models/__init__.py
+++ b/src/livekit/wakeword/models/__init__.py
@@ -1,1 +1,15 @@
 """Neural network models for wake word detection."""
+
+from .classifier import DNNClassifier, FCNBlock, RNNClassifier, build_classifier
+from .feature_extractor import MelSpectrogramFrontend, SpeechEmbedding
+from .pipeline import WakeWordClassifier
+
+__all__ = [
+    "DNNClassifier",
+    "FCNBlock",
+    "MelSpectrogramFrontend",
+    "RNNClassifier",
+    "SpeechEmbedding",
+    "WakeWordClassifier",
+    "build_classifier",
+]

--- a/src/livekit/wakeword/training/__init__.py
+++ b/src/livekit/wakeword/training/__init__.py
@@ -1,1 +1,13 @@
 """Training loop and metrics."""
+
+from .metrics import accuracy, evaluate_model, false_positives_per_hour, recall_at_threshold
+from .trainer import WakeWordTrainer, run_train
+
+__all__ = [
+    "WakeWordTrainer",
+    "accuracy",
+    "evaluate_model",
+    "false_positives_per_hour",
+    "recall_at_threshold",
+    "run_train",
+]


### PR DESCRIPTION
## Summary
- Add re-exports and `__all__` to `data`, `export`, `models`, and `training` subpackages
- Users can now import directly from the package level (e.g. `from livekit.wakeword.data import AudioAugmentor`)
- `inference` and `resources` already had proper exports — no changes needed

## Test plan
- [x] All 38 existing tests pass
- [x] Python syntax verified on all edited files