### PR TITLE
Fix docs discrepancies with actual code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ uv run livekit-wakeword generate <config> # VITS TTS + SLERP speaker blending + 
 uv run livekit-wakeword augment <config>  # Augment + extract features → .npy
 uv run livekit-wakeword train <config>    # 3-phase adaptive training
 uv run livekit-wakeword export <config>   # Export classifier to ONNX
-uv run livekit-wakeword run <config>      # Full pipeline (generate→augment→train→export)
+uv run livekit-wakeword run <config>      # Full pipeline (generate→augment→extract→train→export)
 ```
 
 ## Architecture
@@ -45,7 +45,7 @@ Raw audio (16kHz) → MelSpectrogramFrontend (ONNX) → SpeechEmbedding (ONNX) �
 
 ### Source Layout (`src/livekit/wakeword/`)
 
-- **`config.py`** — Pydantic models + YAML loading (`WakeWordConfig.load_config()`)
+- **`config.py`** — Pydantic models + YAML loading (`load_config(path)`)
 - **`cli.py`** — Typer CLI with all commands
 - **`models/`**
   - `feature_extractor.py` — `MelSpectrogramFrontend` (ONNX primary, torchaudio fallback) and `SpeechEmbedding` (ONNX only)
@@ -73,7 +73,7 @@ Raw audio (16kHz) → MelSpectrogramFrontend (ONNX) → SpeechEmbedding (ONNX) �
 - **Model sizes** (tiny/small/medium/large) map to `layer_dim` and `n_blocks` in config. Factory: `build_classifier(model_type, model_size)`.
 - **Training loss**: BCE with hard example mining (only non-trivial predictions contribute) and linearly increasing negative class weight.
 - **Checkpoint averaging**: final model averages top checkpoints by 90th-pct accuracy and 10th-pct FPPH.
-- **Config format**: YAML loaded via `WakeWordConfig.load_config(path)`. See `configs/hey_livekit.yaml` for reference.
+- **Config format**: YAML loaded via `load_config(path)`. See `configs/hey_livekit.yaml` for reference.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Or run stages individually:
 
 ```bash
 uv run livekit-wakeword generate configs/hey_livekit.yaml  # TTS synthesis + adversarial negatives
-uv run livekit-wakeword augment configs/hey_livekit.yaml   # Add noise, reverb, pitch shifts
+uv run livekit-wakeword augment configs/hey_livekit.yaml   # Augment + extract features
 uv run livekit-wakeword train configs/hey_livekit.yaml     # 3-phase adaptive training
 uv run livekit-wakeword export configs/hey_livekit.yaml    # Export to ONNX
 ```
@@ -132,7 +132,7 @@ target_phrases:
 n_samples: 10000 # training samples per class
 model:
   model_type: dnn # dnn or rnn
-  model_size: medium # tiny, small, medium, large
+  model_size: small # tiny, small, medium, large
 steps: 50000
 target_fp_per_hour: 0.2
 ```
@@ -155,6 +155,7 @@ from livekit.wakeword import (
     load_config,
     run_generate,
     run_augment,
+    run_extraction,
     run_train,
     run_export,
 )
@@ -171,10 +172,11 @@ config = WakeWordConfig(
 )
 
 # Run individual stages
-run_generate(config)   # TTS synthesis + adversarial negatives
-run_augment(config)    # Augment + feature extraction
-run_train(config)      # 3-phase adaptive training
-run_export(config)     # Export to ONNX
+run_generate(config)     # TTS synthesis + adversarial negatives
+run_augment(config)      # Add noise, reverb, pitch shifts
+run_extraction(config)   # Extract mel spectrograms + speech embeddings → .npy
+run_train(config)        # 3-phase adaptive training
+run_export(config)       # Export to ONNX
 ```
 
 This is useful for integrating wake word training into larger pipelines, automating model iteration, or building custom tooling on top of the data generation and training stages.

--- a/docs/augmentation.md
+++ b/docs/augmentation.md
@@ -49,18 +49,6 @@ Applied via the `audiomentations` library to individual clips:
 | `SevenBandParametricEQ` | 0.25 | 7-band parametric equalizer |
 | `TanhDistortion` | 0.25 | Tanh-based distortion |
 
-### Batch Augmentations
-
-Applied via `torch_audiomentations` on batches of audio tensors:
-
-| Transform | Parameters | Probability |
-|-----------|-----------|-------------|
-| `PitchShift` | -3 to +3 semitones | 0.25 |
-| `BandStopFilter` | Notch filter | 0.25 |
-| `AddColoredNoise` | Colored noise injection | 0.25 |
-| `AddBackgroundNoise` | SNR: -10 to 15 dB | 0.75 (if background files exist) |
-| `Gain` | max 0.0 dB | 1.0 (normalization, always applied) |
-
 ### RIR Convolution
 
 `apply_rir(audio, p=0.5)` convolves audio with a randomly selected room impulse response using FFT convolution (`scipy.signal.fftconvolve`). The RIR is normalized by its maximum absolute value before convolution. Output is cropped to the original audio length.

--- a/docs/data-generation.md
+++ b/docs/data-generation.md
@@ -52,7 +52,7 @@ The Cartesian product of `slerp_weights`, `length_scales`, `noise_scales`, and `
 
 ### TTS Model
 
-The `en-us-libritts-high.pt` VITS checkpoint (~255 MB) and its `.json` config are downloaded during `livekit-wakeword setup` to `data/piper/`. If the model is missing or generation fails, 1-second silence placeholders are written and a warning is logged.
+The `en-us-libritts-high.pt` VITS checkpoint (~166 MB) and its `.json` config are downloaded during `livekit-wakeword setup` to `data/piper/`. If the model is missing or generation fails, 1-second silence placeholders are written and a warning is logged.
 
 ### Default Sample Counts
 
@@ -75,13 +75,13 @@ The `en-us-libritts-high.pt` VITS checkpoint (~255 MB) and its `.json` config ar
    - Look up the phoneme sequence for each word
    - For each phoneme, try substituting it with similar phonemes from `SIMILAR_PHONEMES`
    - Look up words matching the substituted phoneme sequence (up to 3 per substitution)
-   - Generate partial phrases (one word removed at a time) with probability `include_partial_phrase` (default: 1.0)
+   - With probability `include_partial_phrase` (default: 1.0), generate all partial phrases (each word removed in turn)
    - Include individual words with probability `include_input_words` (default: 0.2)
 4. Deduplicate, shuffle, and limit to `n_phrases` (default: 200)
 
 ### SIMILAR_PHONEMES Map
 
-The `SIMILAR_PHONEMES` dictionary maps 43 ARPAbet phonemes to phonetically similar alternatives. Examples:
+The `SIMILAR_PHONEMES` dictionary maps 39 ARPAbet phonemes to phonetically similar alternatives. Examples:
 
 | Phoneme | Similar |
 |---------|---------|

--- a/docs/feature-extraction.md
+++ b/docs/feature-extraction.md
@@ -200,7 +200,7 @@ Left-padding places zeros at the **beginning** of the sequence, so the real audi
 
 Each `.npy` file contains a float32 array of shape `(N_clips, 16, 96)`.
 
-Processing is batched (default `batch_size=32`) for efficiency. Audio files are read via `soundfile`, converted to float32, and reduced to mono if stereo.
+Audio files are read via `soundfile`, converted to float32, reduced to mono if stereo, and processed one clip at a time.
 
 ## Memory-Mapped Dataset
 


### PR DESCRIPTION
## Summary
- **README**: Add `run_extraction` to Python API example, fix `model_size` default (`small` not `medium`), update CLI augment comment
- **AGENTS.md**: Add extract step to `run` pipeline description, fix `load_config` references (standalone function, not class method)
- **data-generation.md**: Fix TTS model size (~166 MB not ~255 MB), fix `SIMILAR_PHONEMES` count (39 not 43), clarify `include_partial_phrase` behavior
- **augmentation.md**: Remove batch augmentations section (`augment_batch()` is never called in the pipeline)
- **feature-extraction.md**: Remove false `batch_size=32` claim (clips are processed one at a time)

## Test plan
- [x] Review each fix against source code
- [ ] No code changes — docs only