### PR TITLE
Fix listener blocking: stateless model + async audio buffering

### DIFF
--- a/docs/export-and-inference.md
+++ b/docs/export-and-inference.md
@@ -42,15 +42,15 @@ livekit-wakeword export configs/hey_jarvis.yaml --quantize
 
 ### WakeWordModel
 
-The `WakeWordModel` class provides a simple prediction API for wake word detection.
+The `WakeWordModel` class is a stateless prediction API for wake word detection. Pass a complete audio window (~2 seconds) and receive confidence scores.
 
 ```python
 from livekit.wakeword import WakeWordModel
 
 model = WakeWordModel(models=["hey_livekit.onnx"])
 
-# Feed audio frames (16kHz, int16 or float32)
-scores = model.predict(audio_frame)
+# Pass ~2 seconds of 16kHz audio
+scores = model.predict(audio_chunk)
 # Returns: {"hey_livekit": 0.95}
 ```
 
@@ -68,15 +68,14 @@ Feature extraction models (`melspectrogram.onnx`, `embedding_model.onnx`) are bu
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `predict(audio_frame)` | `dict[str, float]` | Scores for each loaded model (0-1) |
+| `predict(audio_chunk)` | `dict[str, float]` | Scores for each loaded model (0-1) |
 | `load_model(path, name)` | `None` | Load additional wake word model |
-| `reset()` | `None` | Clear internal buffers |
 
 #### Audio Input
 
 - **Format:** 16kHz mono, int16 or float32
-- **Frame size:** Multiples of 80ms (1280 samples) recommended
-- **Buffering:** Internal sliding window handles accumulation
+- **Chunk size:** ~2 seconds (32,000 samples) recommended — yields 16 embeddings for the classifier
+- **Stateless:** No internal audio buffering; the caller manages the audio window
 
 ### WakeWordListener
 

--- a/examples/inference.py
+++ b/examples/inference.py
@@ -9,13 +9,17 @@ from livekit.wakeword import WakeWordModel
 # Load model
 model = WakeWordModel(models=[Path(__file__).parent / "resources" / "hey_livekit.onnx"])
 
-# Simulate 3 seconds of random audio (16kHz) - need ~2s to fill embedding buffer
+# Simulate 3 seconds of random audio (16kHz)
 audio = np.random.randint(-32768, 32767, size=48000, dtype=np.int16)
 
-# Process in 80ms chunks (1280 samples)
-for i in range(0, len(audio), 1280):
-    frame = audio[i : i + 1280]
-    scores = model.predict(frame)
+# The model is stateless — pass a ~2-second chunk and get scores back.
+# Slide a 2-second window over the audio with a 320ms stride.
+CHUNK = 32000  # 2 seconds at 16 kHz
+STRIDE = 1280 * 4  # 320ms
+
+for start in range(0, len(audio) - CHUNK + 1, STRIDE):
+    chunk = audio[start : start + CHUNK]
+    scores = model.predict(chunk)
 
     for name, score in scores.items():
-        print(f"{name}: {score:.4f}")
+        print(f"[{start / 16000:.2f}s] {name}: {score:.4f}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ export = [
     "onnxruntime>=1.17",
     "onnxscript>=0.6.2",
 ]
-dev = ["pytest>=8.0", "pytest-cov>=4.0", "ruff>=0.4", "mypy>=1.8"]
+dev = ["pytest>=8.0", "pytest-cov>=4.0", "pytest-asyncio>=0.23", "ruff>=0.4", "mypy>=1.8"]
 
 [project.scripts]
 livekit-wakeword = "livekit.wakeword.cli:app"
@@ -66,6 +66,7 @@ include = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+asyncio_mode = "auto"
 
 [tool.ruff]
 target-version = "py311"

--- a/src/livekit/wakeword/inference/listener.py
+++ b/src/livekit/wakeword/inference/listener.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
+import logging
 import time
 from dataclasses import dataclass
 
 import numpy as np
 
 from .model import WakeWordModel
+
+logger = logging.getLogger(__name__)
 
 SAMPLE_RATE = 16000
 FRAME_SAMPLES = 1280  # 80ms
@@ -56,11 +60,27 @@ class WakeWordListener:
 
         self._stream = None
         self._pa = None
+        self._task: asyncio.Task | None = None
         self._running = False
         self._last_detection_time = 0.0
         self._detection_queue: asyncio.Queue[Detection] = asyncio.Queue()
 
-    async def __aenter__(self) -> "WakeWordListener":
+        # Error propagation: stored exception from _audio_loop crash
+        self._error: BaseException | None = None
+
+        # Single-thread executor serializes predict() and reset() calls,
+        # ensuring thread safety without locks on the model's mutable state.
+        self._executor: concurrent.futures.ThreadPoolExecutor | None = None
+
+        # Pause/resume control: cleared after detection, set when consumer
+        # calls wait_for_detection() again.
+        self._listening = asyncio.Event()
+
+        # Signals when _audio_loop exits (success or crash) so
+        # wait_for_detection() can raise instead of hanging forever.
+        self._done_event = asyncio.Event()
+
+    async def __aenter__(self) -> WakeWordListener:
         """Start audio capture."""
         import pyaudio
 
@@ -73,18 +93,37 @@ class WakeWordListener:
             frames_per_buffer=FRAME_SAMPLES,
         )
         self._running = True
+        self._listening.set()
+        self._done_event.clear()
+        self._error = None
+        self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         self._task = asyncio.create_task(self._audio_loop())
         return self
 
-    async def __aexit__(self, *_) -> None:
-        """Stop audio capture."""
+    async def __aexit__(self, *_: object) -> None:
+        """Stop audio capture with safe shutdown sequence."""
+        # 1. Signal the loop to stop
         self._running = False
+        # Unblock if paused so the loop can see _running=False
+        self._listening.set()
+
+        # 2. Let the loop exit naturally (worst case: one 80ms read finishes)
         if self._task:
-            self._task.cancel()
             try:
-                await self._task
-            except asyncio.CancelledError:
-                pass
+                await asyncio.wait_for(self._task, timeout=2.0)
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                self._task.cancel()
+                try:
+                    await self._task
+                except asyncio.CancelledError:
+                    pass
+
+        # 3. Wait for any in-flight executor work to complete
+        if self._executor:
+            self._executor.shutdown(wait=True)
+            self._executor = None
+
+        # 4. Now safe to close stream — no thread is reading from it
         if self._stream:
             self._stream.stop_stream()
             self._stream.close()
@@ -95,27 +134,101 @@ class WakeWordListener:
         """Background task that captures audio and runs detection."""
         loop = asyncio.get_event_loop()
 
-        while self._running:
-            # Read audio in executor to not block
-            data = await loop.run_in_executor(
-                None,
-                lambda: self._stream.read(FRAME_SAMPLES, exception_on_overflow=False),
-            )
-            frame = np.frombuffer(data, dtype=np.int16)
+        try:
+            while self._running:
+                # Block here when paused (after detection, until consumer resumes)
+                await self._listening.wait()
+                if not self._running:
+                    break
 
-            # Run inference
-            scores = self._model.predict(frame)
+                # Read audio in executor to not block event loop
+                data = await loop.run_in_executor(
+                    self._executor,
+                    lambda: self._stream.read(  # type: ignore[union-attr]
+                        FRAME_SAMPLES, exception_on_overflow=False
+                    ),
+                )
+                if not self._running:
+                    break
 
-            # Check for detections
-            now = time.monotonic()
-            for name, score in scores.items():
-                if score >= self._threshold:
-                    if now - self._last_detection_time >= self._debounce:
-                        self._last_detection_time = now
-                        await self._detection_queue.put(
-                            Detection(name=name, confidence=score, timestamp=now)
-                        )
+                frame = np.frombuffer(data, dtype=np.int16)
+
+                # Run inference in executor to not block event loop (CPU-bound)
+                scores = await loop.run_in_executor(
+                    self._executor,
+                    self._model.predict,
+                    frame,
+                )
+                if not self._running:
+                    break
+
+                # Check for detections (lightweight, fine on event loop)
+                now = time.monotonic()
+                for name, score in scores.items():
+                    if score >= self._threshold:
+                        if now - self._last_detection_time >= self._debounce:
+                            self._last_detection_time = now
+
+                            # Pause the loop so no audio is processed while
+                            # the consumer handles the detection
+                            self._listening.clear()
+
+                            # Reset model buffers to clear stale wake word data
+                            await loop.run_in_executor(
+                                self._executor, self._model.reset
+                            )
+
+                            await self._detection_queue.put(
+                                Detection(
+                                    name=name, confidence=score, timestamp=now
+                                )
+                            )
+                            break  # one detection per iteration
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.error("Audio loop crashed: %s", exc, exc_info=True)
+            self._error = exc
+        finally:
+            self._done_event.set()
 
     async def wait_for_detection(self) -> Detection:
-        """Wait for and return the next wake word detection."""
-        return await self._detection_queue.get()
+        """Wait for and return the next wake word detection.
+
+        Resumes the audio loop if it was paused after a previous detection.
+
+        Raises:
+            RuntimeError: If the background audio loop has crashed.
+        """
+        # Resume listening (no-op if already active)
+        self._listening.set()
+
+        # Race: either we get a detection, or the audio loop dies
+        queue_waiter = asyncio.ensure_future(self._detection_queue.get())
+        done_waiter = asyncio.ensure_future(self._done_event.wait())
+
+        done, pending = await asyncio.wait(
+            {queue_waiter, done_waiter},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        for task in pending:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        if queue_waiter in done:
+            return queue_waiter.result()
+
+        # Loop ended — check if there's still a queued detection
+        if not self._detection_queue.empty():
+            return self._detection_queue.get_nowait()
+
+        if self._error is not None:
+            raise RuntimeError(
+                f"Audio loop crashed: {self._error}"
+            ) from self._error
+
+        raise RuntimeError("Audio loop ended unexpectedly")

--- a/src/livekit/wakeword/inference/listener.py
+++ b/src/livekit/wakeword/inference/listener.py
@@ -6,6 +6,7 @@ import asyncio
 import concurrent.futures
 import logging
 import time
+from collections import deque
 from dataclasses import dataclass
 
 import numpy as np
@@ -15,7 +16,10 @@ from .model import WakeWordModel
 logger = logging.getLogger(__name__)
 
 SAMPLE_RATE = 16000
-FRAME_SAMPLES = 1280  # 80ms
+FRAME_SAMPLES = 1280  # 80ms per frame
+CHUNK_SECONDS = 2.0
+# Number of frames that fill a ~2-second chunk (25 × 80ms = 2000ms)
+CHUNK_FRAMES = int(CHUNK_SECONDS * SAMPLE_RATE / FRAME_SAMPLES)
 
 
 @dataclass
@@ -29,6 +33,11 @@ class Detection:
 
 class WakeWordListener:
     """Async wake word listener that handles audio capture.
+
+    The listener owns the audio buffer and passes fixed ~2-second chunks
+    to the stateless ``WakeWordModel.predict()``.  After a detection the
+    loop pauses automatically and resumes when the consumer calls
+    ``wait_for_detection()`` again.
 
     Example:
         from livekit.wakeword import WakeWordModel, WakeWordListener
@@ -68,8 +77,7 @@ class WakeWordListener:
         # Error propagation: stored exception from _audio_loop crash
         self._error: BaseException | None = None
 
-        # Single-thread executor serializes predict() and reset() calls,
-        # ensuring thread safety without locks on the model's mutable state.
+        # Single-thread executor keeps predict() off the event loop
         self._executor: concurrent.futures.ThreadPoolExecutor | None = None
 
         # Pause/resume control: cleared after detection, set when consumer
@@ -79,6 +87,9 @@ class WakeWordListener:
         # Signals when _audio_loop exits (success or crash) so
         # wait_for_detection() can raise instead of hanging forever.
         self._done_event = asyncio.Event()
+
+        # Sliding window of recent audio frames (listener owns the buffer)
+        self._frame_buffer: deque[np.ndarray] = deque(maxlen=CHUNK_FRAMES)
 
     async def __aenter__(self) -> WakeWordListener:
         """Start audio capture."""
@@ -96,6 +107,7 @@ class WakeWordListener:
         self._listening.set()
         self._done_event.clear()
         self._error = None
+        self._frame_buffer.clear()
         self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         self._task = asyncio.create_task(self._audio_loop())
         return self
@@ -152,12 +164,18 @@ class WakeWordListener:
                     break
 
                 frame = np.frombuffer(data, dtype=np.int16)
+                self._frame_buffer.append(frame)
 
-                # Run inference in executor to not block event loop (CPU-bound)
+                # Wait until the buffer has enough audio for the model
+                if len(self._frame_buffer) < CHUNK_FRAMES:
+                    continue
+
+                # Build the audio chunk and run inference in executor
+                chunk = np.concatenate(list(self._frame_buffer))
                 scores = await loop.run_in_executor(
                     self._executor,
                     self._model.predict,
-                    frame,
+                    chunk,
                 )
                 if not self._running:
                     break
@@ -169,14 +187,11 @@ class WakeWordListener:
                         if now - self._last_detection_time >= self._debounce:
                             self._last_detection_time = now
 
-                            # Pause the loop so no audio is processed while
-                            # the consumer handles the detection
+                            # Pause the loop and clear the buffer so no stale
+                            # audio is processed while the consumer handles
+                            # the detection.
                             self._listening.clear()
-
-                            # Reset model buffers to clear stale wake word data
-                            await loop.run_in_executor(
-                                self._executor, self._model.reset
-                            )
+                            self._frame_buffer.clear()
 
                             await self._detection_queue.put(
                                 Detection(

--- a/src/livekit/wakeword/inference/model.py
+++ b/src/livekit/wakeword/inference/model.py
@@ -178,6 +178,7 @@ class WakeWordModel:
 
     def reset(self) -> None:
         """Reset internal audio buffers. Call when starting a new audio stream."""
+        logger.debug("Resetting audio and embedding buffers")
         self._audio_buffer = np.zeros(0, dtype=np.float32)
         self._mel_frame_count = 0
         self._embedding_buffer.clear()

--- a/src/livekit/wakeword/inference/model.py
+++ b/src/livekit/wakeword/inference/model.py
@@ -1,9 +1,8 @@
-"""Simple API for wake word detection, similar to openwakeword."""
+"""Stateless wake word detection model."""
 
 from __future__ import annotations
 
 import logging
-from collections import deque
 from pathlib import Path
 
 import numpy as np
@@ -14,22 +13,24 @@ from ..resources import get_embedding_model_path, get_mel_model_path
 logger = logging.getLogger(__name__)
 
 SAMPLE_RATE = 16000
+EMBEDDING_WINDOW = 76  # mel frames per embedding
+EMBEDDING_STRIDE = 8  # mel frames between embeddings
+MIN_EMBEDDINGS = 16  # classifier input length
 
 
 class WakeWordModel:
-    """Simple API for wake word detection, similar to openwakeword.
+    """Stateless wake word detection model.
+
+    The model is a pure function: pass an audio chunk (~2 seconds at 16 kHz)
+    and receive confidence scores.  No internal audio state is maintained.
 
     Example usage:
         from livekit.wakeword import WakeWordModel
 
-        # Load wake word model(s)
         model = WakeWordModel(models=["path/to/model.onnx"])
 
-        # Get audio frame (16-bit 16kHz PCM, multiples of 80ms recommended)
-        frame = get_audio_frame()
-
-        # Get predictions
-        prediction = model.predict(frame)
+        # Pass ~2 seconds of 16 kHz audio
+        scores = model.predict(audio_chunk)
         # Returns: {"model_name": 0.95, ...}
     """
 
@@ -43,8 +44,6 @@ class WakeWordModel:
             models: List of paths to wake word ONNX classifier models.
                 If None, no models are loaded (call load_model() later).
         """
-
-        # Load bundled feature extraction models
         mel_path = get_mel_model_path()
         embedding_path = get_embedding_model_path()
 
@@ -62,18 +61,9 @@ class WakeWordModel:
         self._mel_frontend = MelSpectrogramFrontend(onnx_path=mel_path)
         self._speech_embedding = SpeechEmbedding(onnx_path=embedding_path)
 
-        # Store wake word classifiers: name -> (session, input_name)
+        # name -> (onnx_session, input_name)
         self._classifiers: dict[str, tuple] = {}
 
-        # Audio processing state (shared across all models)
-        self._max_audio_seconds = 3.0
-        self._audio_buffer = np.zeros(0, dtype=np.float32)
-        self._mel_frame_count = 0
-        self._embedding_buffer: deque[np.ndarray] = deque(maxlen=16)
-        self._mel_frames_since_embedding = 0
-        self._last_scores: dict[str, float] = {}
-
-        # Load provided models
         if models:
             for model_path in models:
                 self.load_model(model_path)
@@ -100,71 +90,51 @@ class WakeWordModel:
         )
         input_name = session.get_inputs()[0].name
         self._classifiers[model_name] = (session, input_name)
-        self._last_scores[model_name] = 0.0
         logger.info(f"Loaded wake word model '{model_name}' from {model_path}")
 
-    def predict(self, audio_frame: np.ndarray) -> dict[str, float]:
-        """Get wake word predictions for an audio frame.
+    def predict(self, audio_chunk: np.ndarray) -> dict[str, float]:
+        """Get wake word predictions for an audio chunk.
+
+        The model is stateless — pass a complete audio window each time.
+        ~2 seconds of 16 kHz audio is recommended (yields exactly 16
+        embeddings for the classifier).  Shorter chunks that lack enough
+        data return zero scores.
 
         Args:
-            audio_frame: Audio samples at 16kHz. Can be:
-                - int16 array (will be converted to float32)
-                - float32 array (values in [-1, 1])
-                For best efficiency, use multiples of 80ms (1280 samples).
+            audio_chunk: Audio samples at 16 kHz. Can be int16 or float32.
 
         Returns:
             Dictionary mapping model names to prediction scores (0-1).
         """
-        if len(self._classifiers) == 0:
+        if not self._classifiers:
             return {}
 
         # Convert int16 to float32 if needed
-        if audio_frame.dtype == np.int16:
-            audio_frame = audio_frame.astype(np.float32) / 32768.0
+        if audio_chunk.dtype == np.int16:
+            audio_chunk = audio_chunk.astype(np.float32) / 32768.0
 
-        # Ensure 1D
-        audio_frame = audio_frame.flatten()
+        audio_chunk = audio_chunk.flatten()
 
-        # Accumulate audio and compute mel spectrogram
-        self._audio_buffer = np.concatenate([self._audio_buffer, audio_frame])
-
-        all_mel = self._mel_frontend(self._audio_buffer)
+        # Mel spectrogram over the full chunk
+        all_mel = self._mel_frontend(audio_chunk)
         if all_mel.ndim == 3:
             all_mel = all_mel[0]
 
-        new_mel_frames = all_mel.shape[0] - self._mel_frame_count
-        self._mel_frame_count = all_mel.shape[0]
-        self._mel_frames_since_embedding += new_mel_frames
-
-        # Need at least 76 mel frames for one embedding window
-        if all_mel.shape[0] < 76:
+        if all_mel.shape[0] < EMBEDDING_WINDOW:
             return {name: 0.0 for name in self._classifiers}
 
-        # Only extract a new embedding every 8 mel frames
-        if self._mel_frames_since_embedding < 8:
-            return dict(self._last_scores)
+        # Extract embeddings: 76-frame windows, stride 8
+        embeddings = []
+        for start in range(0, all_mel.shape[0] - EMBEDDING_WINDOW + 1, EMBEDDING_STRIDE):
+            window = all_mel[start : start + EMBEDDING_WINDOW]
+            emb = self._speech_embedding(window[np.newaxis, :, :])
+            embeddings.append(emb[0])
 
-        # Extract embedding from latest 76-frame window
-        self._mel_frames_since_embedding = 0
-        window = all_mel[-76:]
-        embedding = self._speech_embedding(window[np.newaxis, :, :])
-        self._embedding_buffer.append(embedding[0])
-
-        # Trim audio buffer to avoid unbounded growth
-        max_audio_samples = int(self._max_audio_seconds * SAMPLE_RATE)
-        if len(self._audio_buffer) > max_audio_samples:
-            self._audio_buffer = self._audio_buffer[-max_audio_samples:]
-            trimmed_mel = self._mel_frontend(self._audio_buffer)
-            if trimmed_mel.ndim == 3:
-                trimmed_mel = trimmed_mel[0]
-            self._mel_frame_count = trimmed_mel.shape[0]
-
-        # Need 16 embeddings for classifier
-        if len(self._embedding_buffer) < 16:
+        if len(embeddings) < MIN_EMBEDDINGS:
             return {name: 0.0 for name in self._classifiers}
 
-        # Run all classifiers
-        emb_sequence = np.stack(list(self._embedding_buffer), axis=0)
+        # Use last 16 embeddings
+        emb_sequence = np.stack(embeddings[-MIN_EMBEDDINGS:], axis=0)
         emb_input = emb_sequence[np.newaxis, :, :].astype(np.float32)
 
         predictions = {}
@@ -172,15 +142,5 @@ class WakeWordModel:
             outputs = session.run(None, {input_name: emb_input})
             score = float(outputs[0][0, 0])
             predictions[name] = score
-            self._last_scores[name] = score
 
         return predictions
-
-    def reset(self) -> None:
-        """Reset internal audio buffers. Call when starting a new audio stream."""
-        logger.debug("Resetting audio and embedding buffers")
-        self._audio_buffer = np.zeros(0, dtype=np.float32)
-        self._mel_frame_count = 0
-        self._embedding_buffer.clear()
-        self._mel_frames_since_embedding = 0
-        self._last_scores = {name: 0.0 for name in self._classifiers}

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -1,0 +1,213 @@
+"""Tests for WakeWordListener async behavior."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from livekit.wakeword.inference.listener import (
+    Detection,
+    WakeWordListener,
+    FRAME_SAMPLES,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class FakeModel:
+    """Mock WakeWordModel that returns pre-configured scores."""
+
+    def __init__(self, scores_sequence: list[dict[str, float]] | None = None):
+        self._scores_sequence = scores_sequence or []
+        self._call_count = 0
+        self.reset_count = 0
+
+    def predict(self, frame: np.ndarray) -> dict[str, float]:
+        if self._call_count < len(self._scores_sequence):
+            scores = self._scores_sequence[self._call_count]
+        else:
+            scores = {"test": 0.0}
+        self._call_count += 1
+        return scores
+
+    def reset(self) -> None:
+        self.reset_count += 1
+
+
+class FakeStream:
+    """Mock PyAudio stream that returns silence."""
+
+    def __init__(self, *, error_after: int | None = None):
+        self._error_after = error_after
+        self._read_count = 0
+
+    def read(self, num_frames: int, exception_on_overflow: bool = False) -> bytes:
+        self._read_count += 1
+        if self._error_after is not None and self._read_count > self._error_after:
+            raise IOError("Simulated stream read error")
+        return np.zeros(num_frames, dtype=np.int16).tobytes()
+
+    def stop_stream(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class FakePyAudio:
+    """Mock PyAudio that returns a FakeStream."""
+
+    def __init__(self, stream: FakeStream):
+        self._stream = stream
+
+    def open(self, **kwargs: object) -> FakeStream:
+        return self._stream
+
+    def terminate(self) -> None:
+        pass
+
+
+def _patch_pyaudio(stream: FakeStream):
+    """Return a patch context that replaces pyaudio with a fake."""
+    fake_pa = FakePyAudio(stream)
+    mock_module = MagicMock()
+    mock_module.PyAudio.return_value = fake_pa
+    mock_module.paInt16 = 8  # pyaudio constant
+    return patch.dict("sys.modules", {"pyaudio": mock_module})
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_predict_runs_in_executor():
+    """predict() should execute on a non-main thread (in the executor)."""
+    predict_threads: list[threading.Thread] = []
+
+    class ThreadTrackingModel(FakeModel):
+        def predict(self, frame: np.ndarray) -> dict[str, float]:
+            predict_threads.append(threading.current_thread())
+            return super().predict(frame)
+
+    model = ThreadTrackingModel(scores_sequence=[{"test": 0.0}] * 50)
+    stream = FakeStream()
+
+    with _patch_pyaudio(stream):
+        async with WakeWordListener(model, threshold=0.5) as listener:
+            # Let a few iterations run
+            await asyncio.sleep(0.3)
+
+    assert len(predict_threads) > 0
+    main_thread = threading.main_thread()
+    for t in predict_threads:
+        assert t is not main_thread, "predict() ran on the main thread"
+
+
+@pytest.mark.asyncio
+async def test_error_propagation():
+    """If the audio loop crashes, wait_for_detection raises RuntimeError."""
+
+    class ErrorModel:
+        def predict(self, frame: np.ndarray) -> dict[str, float]:
+            raise ValueError("ONNX inference failed")
+
+        def reset(self) -> None:
+            pass
+
+    model = ErrorModel()
+    stream = FakeStream()
+
+    with _patch_pyaudio(stream):
+        async with WakeWordListener(model, threshold=0.5) as listener:
+            with pytest.raises(RuntimeError, match="Audio loop crashed"):
+                await asyncio.wait_for(listener.wait_for_detection(), timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_stream_error_propagation():
+    """If the audio stream crashes, wait_for_detection raises RuntimeError."""
+    model = FakeModel(scores_sequence=[{"test": 0.0}] * 100)
+    stream = FakeStream(error_after=3)
+
+    with _patch_pyaudio(stream):
+        async with WakeWordListener(model, threshold=0.5) as listener:
+            with pytest.raises(RuntimeError, match="Audio loop crashed"):
+                await asyncio.wait_for(listener.wait_for_detection(), timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_buffer_reset_after_detection():
+    """model.reset() is called after each detection."""
+    scores = [{"test": 0.0}] * 5 + [{"test": 0.9}]
+    model = FakeModel(scores_sequence=scores)
+    stream = FakeStream()
+
+    with _patch_pyaudio(stream):
+        async with WakeWordListener(model, threshold=0.5, debounce=0.0) as listener:
+            detection = await asyncio.wait_for(
+                listener.wait_for_detection(), timeout=5.0
+            )
+            assert detection.name == "test"
+            assert detection.confidence == pytest.approx(0.9)
+            assert model.reset_count == 1
+
+
+@pytest.mark.asyncio
+async def test_loop_pauses_after_detection():
+    """After detection, the loop pauses — no stale detections pile up."""
+    # Provide continuous high scores
+    scores = [{"test": 0.9}] * 200
+    model = FakeModel(scores_sequence=scores)
+    stream = FakeStream()
+
+    with _patch_pyaudio(stream):
+        async with WakeWordListener(model, threshold=0.5, debounce=0.0) as listener:
+            det1 = await asyncio.wait_for(
+                listener.wait_for_detection(), timeout=5.0
+            )
+
+            # Give time for the loop to potentially queue more (it shouldn't)
+            await asyncio.sleep(0.3)
+            assert listener._detection_queue.empty(), (
+                "Loop should be paused — no extra detections in queue"
+            )
+
+            # Second call resumes listening and gets next detection
+            det2 = await asyncio.wait_for(
+                listener.wait_for_detection(), timeout=5.0
+            )
+            assert det2.timestamp > det1.timestamp
+
+
+@pytest.mark.asyncio
+async def test_shutdown_while_paused():
+    """Exiting context manager doesn't hang when loop is paused after detection."""
+    scores = [{"test": 0.0}] * 3 + [{"test": 0.9}]
+    model = FakeModel(scores_sequence=scores)
+    stream = FakeStream()
+
+    with _patch_pyaudio(stream):
+        async with WakeWordListener(model, threshold=0.5) as listener:
+            await asyncio.wait_for(listener.wait_for_detection(), timeout=5.0)
+            # Loop is now paused. Exiting context manager should not hang.
+    # If we reach here, shutdown succeeded.
+
+
+@pytest.mark.asyncio
+async def test_shutdown_during_active_listening():
+    """Exiting context manager completes cleanly during active listening."""
+    model = FakeModel(scores_sequence=[{"test": 0.0}] * 1000)
+    stream = FakeStream()
+
+    with _patch_pyaudio(stream):
+        async with WakeWordListener(model, threshold=0.5) as listener:
+            await asyncio.sleep(0.2)  # let loop run a few iterations
+    # If we reach here without hanging, shutdown is clean.

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from livekit.wakeword.inference.listener import (
+    CHUNK_FRAMES,
     Detection,
     WakeWordListener,
     FRAME_SAMPLES,
@@ -20,24 +21,26 @@ from livekit.wakeword.inference.listener import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 class FakeModel:
-    """Mock WakeWordModel that returns pre-configured scores."""
+    """Mock WakeWordModel that returns pre-configured scores.
+
+    With the stateless model, predict() receives a full ~2-second chunk.
+    The fake ignores the audio data and walks through a pre-configured
+    scores sequence by call index.
+    """
 
     def __init__(self, scores_sequence: list[dict[str, float]] | None = None):
         self._scores_sequence = scores_sequence or []
         self._call_count = 0
-        self.reset_count = 0
 
-    def predict(self, frame: np.ndarray) -> dict[str, float]:
+    def predict(self, audio_chunk: np.ndarray) -> dict[str, float]:
         if self._call_count < len(self._scores_sequence):
             scores = self._scores_sequence[self._call_count]
         else:
             scores = {"test": 0.0}
         self._call_count += 1
         return scores
-
-    def reset(self) -> None:
-        self.reset_count += 1
 
 
 class FakeStream:
@@ -93,17 +96,16 @@ async def test_predict_runs_in_executor():
     predict_threads: list[threading.Thread] = []
 
     class ThreadTrackingModel(FakeModel):
-        def predict(self, frame: np.ndarray) -> dict[str, float]:
+        def predict(self, audio_chunk: np.ndarray) -> dict[str, float]:
             predict_threads.append(threading.current_thread())
-            return super().predict(frame)
+            return super().predict(audio_chunk)
 
     model = ThreadTrackingModel(scores_sequence=[{"test": 0.0}] * 50)
     stream = FakeStream()
 
     with _patch_pyaudio(stream):
         async with WakeWordListener(model, threshold=0.5) as listener:
-            # Let a few iterations run
-            await asyncio.sleep(0.3)
+            await asyncio.sleep(0.5)
 
     assert len(predict_threads) > 0
     main_thread = threading.main_thread()
@@ -116,11 +118,8 @@ async def test_error_propagation():
     """If the audio loop crashes, wait_for_detection raises RuntimeError."""
 
     class ErrorModel:
-        def predict(self, frame: np.ndarray) -> dict[str, float]:
+        def predict(self, audio_chunk: np.ndarray) -> dict[str, float]:
             raise ValueError("ONNX inference failed")
-
-        def reset(self) -> None:
-            pass
 
     model = ErrorModel()
     stream = FakeStream()
@@ -135,6 +134,7 @@ async def test_error_propagation():
 async def test_stream_error_propagation():
     """If the audio stream crashes, wait_for_detection raises RuntimeError."""
     model = FakeModel(scores_sequence=[{"test": 0.0}] * 100)
+    # Error before buffer fills (< CHUNK_FRAMES reads)
     stream = FakeStream(error_after=3)
 
     with _patch_pyaudio(stream):
@@ -144,9 +144,10 @@ async def test_stream_error_propagation():
 
 
 @pytest.mark.asyncio
-async def test_buffer_reset_after_detection():
-    """model.reset() is called after each detection."""
-    scores = [{"test": 0.0}] * 5 + [{"test": 0.9}]
+async def test_buffer_cleared_after_detection():
+    """Listener's frame buffer is cleared after each detection."""
+    # First predict call returns a high score → detection
+    scores = [{"test": 0.9}]
     model = FakeModel(scores_sequence=scores)
     stream = FakeStream()
 
@@ -157,13 +158,30 @@ async def test_buffer_reset_after_detection():
             )
             assert detection.name == "test"
             assert detection.confidence == pytest.approx(0.9)
-            assert model.reset_count == 1
+            # Buffer should be empty after detection
+            assert len(listener._frame_buffer) == 0
+
+
+@pytest.mark.asyncio
+async def test_predict_not_called_until_buffer_full():
+    """predict() is not called until CHUNK_FRAMES of audio have been read."""
+    model = FakeModel(scores_sequence=[{"test": 0.0}] * 100)
+    # Error at frame CHUNK_FRAMES - 1 (before buffer would fill)
+    stream = FakeStream(error_after=CHUNK_FRAMES - 1)
+
+    with _patch_pyaudio(stream):
+        async with WakeWordListener(model, threshold=0.5) as listener:
+            with pytest.raises(RuntimeError, match="Audio loop crashed"):
+                await asyncio.wait_for(listener.wait_for_detection(), timeout=5.0)
+
+    # predict() should never have been called — buffer never filled
+    assert model._call_count == 0
 
 
 @pytest.mark.asyncio
 async def test_loop_pauses_after_detection():
     """After detection, the loop pauses — no stale detections pile up."""
-    # Provide continuous high scores
+    # Continuous high scores
     scores = [{"test": 0.9}] * 200
     model = FakeModel(scores_sequence=scores)
     stream = FakeStream()
@@ -190,7 +208,8 @@ async def test_loop_pauses_after_detection():
 @pytest.mark.asyncio
 async def test_shutdown_while_paused():
     """Exiting context manager doesn't hang when loop is paused after detection."""
-    scores = [{"test": 0.0}] * 3 + [{"test": 0.9}]
+    # First predict returns detection
+    scores = [{"test": 0.9}]
     model = FakeModel(scores_sequence=scores)
     stream = FakeStream()
 

--- a/uv.lock
+++ b/uv.lock
@@ -766,6 +766,7 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
@@ -805,6 +806,7 @@ requires-dist = [
     { name = "pyaudio", specifier = ">=0.2.14" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
@@ -1770,6 +1772,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- **Make `WakeWordModel` stateless**: `predict()` now takes a complete ~2-second audio chunk and returns scores with no internal audio state. Removes the `reset()` method entirely.
- **Move audio buffering to `WakeWordListener`**: The listener owns a sliding `deque` of audio frames and assembles chunks before calling `predict()`. After detection the buffer is cleared instead of calling `model.reset()`.
- **Add dedicated thread executor**: `predict()` runs in a single-thread executor to keep CPU-bound inference off the event loop.

## Test plan
- [x] Updated existing tests to match stateless model API
- [x] Added `test_predict_not_called_until_buffer_full` to verify buffering behavior
- [x] Updated `test_buffer_cleared_after_detection` (replaces `test_buffer_reset_after_detection`)
- [ ] Run `pytest tests/` to verify all tests pass
- [ ] Manual test with microphone using `examples/inference.py`