### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/livekit/livekit-wakeword/security/code-scanning/1](https://github.com/livekit/livekit-wakeword/security/code-scanning/1)

In general, this problem is fixed by adding an explicit `permissions` block to the workflow (at the root) or to individual jobs, restricting the `GITHUB_TOKEN` to the least privileges necessary. For a typical CI test workflow that only checks out code and runs tests, `contents: read` is sufficient; if the workflow also pulls packages from GitHub Packages, `packages: read` may be added.

For this specific workflow in `.github/workflows/ci.yml`, the simplest change without altering functionality is to define a workflow-level permissions block right under the `name: CI` line. That will apply to all jobs that do not have their own `permissions` key, including the shown `test` job. Given the current steps (checkout, install dependencies, run tests) no write permissions are needed, so we can set:
```yaml
permissions:
  contents: read
```
This keeps the token read-only for repository contents while leaving all existing behavior intact. No additional imports or methods are needed, as this is pure YAML configuration.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert a `permissions` section after line 1 (`name: CI`) and before the `on:` block.
- Use `contents: read` as the minimal starting point.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
