### PR TITLE
Copy only model artifacts to bucket in SkyPilot

### DIFF
--- a/skypilot/train.yaml
+++ b/skypilot/train.yaml
@@ -24,7 +24,10 @@ setup: |
 run: |
   export PATH="$HOME/.cargo/bin:$PATH"
   uv run livekit-wakeword run configs/${CONFIG_FILE}
-  cp -r output/${MODEL_NAME}/* /outputs/${MODEL_NAME}/
+  mkdir -p /outputs/${MODEL_NAME}
+  cp output/${MODEL_NAME}/${MODEL_NAME}.pt /outputs/${MODEL_NAME}/
+  cp output/${MODEL_NAME}/${MODEL_NAME}.onnx /outputs/${MODEL_NAME}/
+  cp output/${MODEL_NAME}/metrics.json /outputs/${MODEL_NAME}/
 
 envs:
   CONFIG_FILE: prod.yaml


### PR DESCRIPTION
## Summary
- Replace `cp -r output/${MODEL_NAME}/*` with explicit copies of only the model artifacts (`.pt`, `.onnx`, `metrics.json`)
- Avoids uploading intermediate training data (generated audio, augmented clips, `.npy` feature files) to the bucket

## Test plan
- [ ] Run a SkyPilot training job and verify only the three artifact files appear in the bucket