### PR TITLE
Switch SkyPilot training to L40S with larger disk

### DIFF
--- a/skypilot/train.yaml
+++ b/skypilot/train.yaml
@@ -2,10 +2,10 @@ name: livekit-wakeword-train-hey-livekit
 
 resources:
   cloud: nebius
-  accelerators: H100:1
+  accelerators: L40S:1
   cpus: 8+
   memory: 32+
-  disk_size: 100
+  disk_size: 500
 
 workdir: .
 


### PR DESCRIPTION
## Summary
- Switch GPU accelerator from H100 to L40S for training
- Increase disk size from 100GB to 500GB

## Test plan
- [ ] Verify SkyPilot launches with the updated resource config
- [ ] Confirm training runs successfully on L40S