### PR TITLE
Fix ONNX export to support dynamic batch sizes

### DIFF
--- a/src/livekit/wakeword/export/onnx.py
+++ b/src/livekit/wakeword/export/onnx.py
@@ -22,14 +22,14 @@ def export_classifier(
 ) -> Path:
     """Export classifier head to ONNX.
 
-    Input shape: (1, 16, 96) — pre-extracted embeddings
-    Output shape: (1, 1) — confidence score
+    Input shape: (batch, 16, 96) — pre-extracted embeddings
+    Output shape: (batch, 1) — confidence score
     """
     model = WakeWordClassifier(config)
     model.load_state_dict(torch.load(model_path, map_location="cpu", weights_only=True))
     model.eval()
 
-    dummy_input = torch.randn(1, 16, 96)
+    dummy_input = torch.randn(2, 16, 96)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     torch.onnx.export(

--- a/src/livekit/wakeword/models/classifier.py
+++ b/src/livekit/wakeword/models/classifier.py
@@ -89,7 +89,7 @@ class ConvAttentionClassifier(nn.Module):
         # (batch, layer_dim, 16) → (batch, 16, layer_dim) for attention
         x = x.transpose(1, 2)
         # Self-attention with residual
-        attn_out, _ = self.attention(x, x, x)
+        attn_out, _ = self.attention(x, x, x, need_weights=False)
         x = self.attn_norm(x + attn_out)
         # Mean pool over timesteps → (batch, layer_dim)
         x = x.mean(dim=1)


### PR DESCRIPTION
## Summary
- Trace ONNX export with batch=2 instead of batch=1 so `nn.MultiheadAttention`'s internal reshapes don't bake in the singleton batch dimension, allowing the exported model to run with any batch size
- Pass `need_weights=False` to the attention call to avoid exporting unnecessary attention-weight computation into the ONNX graph

## Test plan
- [x] Existing classifier tests pass (`test_classifier.py`)
- [ ] Export a conv-attention model and verify ONNX inference works with batch sizes > 1