### PR TITLE
Switch HF features repo to binhpham/livekit_wakeword_features

### DIFF
--- a/src/livekit/wakeword/cli.py
+++ b/src/livekit/wakeword/cli.py
@@ -118,7 +118,7 @@ def _download_validation_features(features_dir: Path) -> None:
 
         logger.info("Downloading validation features (~176 MB, ~11hrs)...")
         hf_hub_download(
-            repo_id="davidscripka/openwakeword_features",
+            repo_id="binhpham/livekit_wakeword_features",
             filename="validation_set_features.npy",
             local_dir=str(features_dir),
             repo_type="dataset",
@@ -139,7 +139,7 @@ def _download_features(features_dir: Path) -> None:
 
         logger.info("Downloading ACAV100M features (~16 GB, ~2000hrs)...")
         hf_hub_download(
-            repo_id="davidscripka/openwakeword_features",
+            repo_id="binhpham/livekit_wakeword_features",
             filename="openwakeword_features_ACAV100M_2000_hrs_16bit.npy",
             local_dir=str(features_dir),
             repo_type="dataset",


### PR DESCRIPTION
## Summary
- Update ACAV100M and validation features download to pull from `binhpham/livekit_wakeword_features` instead of `davidscripka/openwakeword_features`

## Test plan
- [ ] Run `uv run livekit-wakeword setup --skip-acav` to verify validation features download
- [ ] Run `uv run livekit-wakeword setup` to verify full ACAV features download