### PR TITLE
Add autostop and persist data dirs for SkyPilot cluster reuse

### DIFF
--- a/skypilot/train.yaml
+++ b/skypilot/train.yaml
@@ -6,6 +6,9 @@ resources:
   cpus: 8+
   memory: 32+
   disk_size: 500
+  autostop:
+    idle_minutes: 10
+    down: false
 
 workdir: .
 

--- a/skypilot/train.yaml
+++ b/skypilot/train.yaml
@@ -43,5 +43,5 @@ run: |
 envs:
   CONFIG_FILE: prod.yaml
   MODEL_NAME: hey_livekit
-  DATA_DIR: /home/skypilot/data
-  OUTPUT_DIR: /home/skypilot/output
+  DATA_DIR: ~/persistent/data
+  OUTPUT_DIR: ~/persistent/output

--- a/skypilot/train.yaml
+++ b/skypilot/train.yaml
@@ -21,19 +21,27 @@ setup: |
   sudo apt-get update && sudo apt-get install -y espeak-ng libsndfile1 ffmpeg sox portaudio19-dev
   curl -LsSf https://astral.sh/uv/install.sh | sh
   export PATH="$HOME/.cargo/bin:$PATH"
+  # Persist data and output outside workdir so they survive re-syncs
+  mkdir -p ${DATA_DIR} ${OUTPUT_DIR}
+  ln -sfn ${DATA_DIR} data
+  ln -sfn ${OUTPUT_DIR} output
   uv sync --extra train --extra export --extra eval
-  uv run livekit-wakeword setup
+  uv run livekit-wakeword setup --data-dir ${DATA_DIR}
 
 run: |
   export PATH="$HOME/.cargo/bin:$PATH"
+  ln -sfn ${DATA_DIR} data
+  ln -sfn ${OUTPUT_DIR} output
   uv run livekit-wakeword run configs/${CONFIG_FILE}
   mkdir -p /outputs/${MODEL_NAME}
-  cp output/${MODEL_NAME}/${MODEL_NAME}.pt /outputs/${MODEL_NAME}/
-  cp output/${MODEL_NAME}/${MODEL_NAME}.onnx /outputs/${MODEL_NAME}/
-  cp output/${MODEL_NAME}/${MODEL_NAME}_metrics.json /outputs/${MODEL_NAME}/
-  cp output/${MODEL_NAME}/${MODEL_NAME}_det.png /outputs/${MODEL_NAME}/
-  cp output/${MODEL_NAME}/${MODEL_NAME}_eval.json /outputs/${MODEL_NAME}/
+  cp ${OUTPUT_DIR}/${MODEL_NAME}/${MODEL_NAME}.pt /outputs/${MODEL_NAME}/
+  cp ${OUTPUT_DIR}/${MODEL_NAME}/${MODEL_NAME}.onnx /outputs/${MODEL_NAME}/
+  cp ${OUTPUT_DIR}/${MODEL_NAME}/${MODEL_NAME}_metrics.json /outputs/${MODEL_NAME}/
+  cp ${OUTPUT_DIR}/${MODEL_NAME}/${MODEL_NAME}_det.png /outputs/${MODEL_NAME}/
+  cp ${OUTPUT_DIR}/${MODEL_NAME}/${MODEL_NAME}_eval.json /outputs/${MODEL_NAME}/
 
 envs:
   CONFIG_FILE: prod.yaml
   MODEL_NAME: hey_livekit
+  DATA_DIR: /home/skypilot/data
+  OUTPUT_DIR: /home/skypilot/output


### PR DESCRIPTION
## Summary
- Add autostop configuration (10 min idle, stop-only) under `resources`
- Persist `data` and `output` dirs outside workdir via symlinks to `/home/skypilot/`
- Uses `down: false` since Nebius doesn't support autodown (can't delete OS disk)

## Details
- Symlink `./data` → `/home/skypilot/data` and `./output` → `/home/skypilot/output` so ACAV features (~16 GB), RIRs, backgrounds, and generated audio survive workdir re-syncs across `sky exec` calls
- Setup command now passes `--data-dir` to download directly to the stable path
- Stopped clusters retain disk, so subsequent jobs skip re-downloading

## Workflow
1. `sky launch skypilot/train.yaml` — provisions cluster, downloads data, trains
2. `sky exec <cluster> skypilot/train.yaml` — reuses cluster + cached data
3. After 10 min idle, cluster auto-stops (disk preserved)
4. `sky start <cluster>` to resume later