### PR TITLE
Prepare package for PyPI publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --group dev --extra train --extra export
+        run: uv sync --extra train --extra export
 
       - name: Run tests
         run: uv run pytest --tb=short -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --extra dev --extra train --extra export
+        run: uv sync --group dev --extra train --extra export
 
       - name: Run tests
         run: uv run pytest --tb=short -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,26 +5,42 @@ build-backend = "hatchling.build"
 [project]
 name = "livekit-wakeword"
 version = "0.1.0"
-description = "Simplified pure-PyTorch wake word detection"
+description = "Wake word detection for voice-enabled applications"
+readme = "README.md"
 requires-python = ">=3.11"
 license = "Apache-2.0"
+authors = [{ name = "LiveKit" }]
+keywords = ["wake-word", "keyword-spotting", "voice", "speech", "livekit", "onnx"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Multimedia :: Sound/Audio :: Speech",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
 
 dependencies = [
-    "torch>=2.2",
-    "torchaudio>=2.2",
     "numpy>=1.24",
     "onnxruntime>=1.17",
+]
+
+[project.optional-dependencies]
+listener = [
+    "pyaudio>=0.2.14",
+]
+train = [
+    "torch>=2.2",
+    "torchaudio>=2.2",
     "pydantic>=2.0",
     "typer>=0.12",
     "pyyaml>=6.0",
     "rich>=13.0",
     "huggingface-hub>=0.20",
-    "pyaudio>=0.2.14",
     "soundfile>=0.12",
-]
-
-[project.optional-dependencies]
-train = [
     "torch-audiomentations>=0.11",
     "audiomentations>=0.36",
     "webrtcvad>=2.0.10",
@@ -46,6 +62,11 @@ export = [
     "onnxscript>=0.6.2",
 ]
 dev = ["pytest>=8.0", "pytest-cov>=4.0", "pytest-asyncio>=0.23", "ruff>=0.4", "mypy>=1.8"]
+
+[project.urls]
+Homepage = "https://github.com/livekit/livekit-wakeword"
+Repository = "https://github.com/livekit/livekit-wakeword"
+Issues = "https://github.com/livekit/livekit-wakeword/issues"
 
 [project.scripts]
 livekit-wakeword = "livekit.wakeword.cli:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,6 @@ export = [
     "onnxruntime>=1.17",
     "onnxscript>=0.6.2",
 ]
-dev = ["pytest>=8.0", "pytest-cov>=4.0", "pytest-asyncio>=0.23", "ruff>=0.4", "mypy>=1.8"]
-
 [project.urls]
 Homepage = "https://github.com/livekit/livekit-wakeword"
 Repository = "https://github.com/livekit/livekit-wakeword"
@@ -87,6 +85,9 @@ include = [
     "src/livekit/wakeword/**/*.py",
     "src/livekit/wakeword/resources/*.onnx",
 ]
+
+[dependency-groups]
+dev = ["pytest>=8.0", "pytest-cov>=4.0", "pytest-asyncio>=0.23", "ruff>=0.4", "mypy>=1.8"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Wake word detection for voice-enabled applications"
 readme = "README.md"
 requires-python = ">=3.11"
 license = "Apache-2.0"
-authors = [{ name = "LiveKit" }]
+authors = [{ name = "Binh Pham", email = "binh.pham@livekit.io" }]
 keywords = ["wake-word", "keyword-spotting", "voice", "speech", "livekit", "onnx"]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/src/livekit/wakeword/__init__.py
+++ b/src/livekit/wakeword/__init__.py
@@ -1,25 +1,31 @@
-"""livekit-wakeword — Simplified pure-PyTorch wake word detection."""
+"""livekit-wakeword — Wake word detection for voice-enabled applications."""
 
-from .config import WakeWordConfig, load_config
-from .data.augment import run_augment
-from .data.features import run_extraction
-from .data.generate import run_generate
 from .inference.listener import Detection, WakeWordListener
 from .inference.model import WakeWordModel
-from .training.trainer import run_train
 
 __version__ = "0.1.0"
 
+# Training / CLI imports are lazy-loaded so that the core inference API
+# works with only numpy + onnxruntime (no torch, pydantic, etc.).
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "WakeWordConfig": (".config", "WakeWordConfig"),
+    "load_config": (".config", "load_config"),
+    "run_augment": (".data.augment", "run_augment"),
+    "run_extraction": (".data.features", "run_extraction"),
+    "run_generate": (".data.generate", "run_generate"),
+    "run_train": (".training.trainer", "run_train"),
+    "run_export": (".export.onnx", "run_export"),
+    "run_eval": (".eval.evaluate", "run_eval"),
+}
+
 
 def __getattr__(name: str) -> object:
-    if name == "run_export":
-        from .export.onnx import run_export
+    if name in _LAZY_IMPORTS:
+        module_path, attr = _LAZY_IMPORTS[name]
+        import importlib
 
-        return run_export
-    if name == "run_eval":
-        from .eval.evaluate import run_eval
-
-        return run_eval
+        mod = importlib.import_module(module_path, __name__)
+        return getattr(mod, attr)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -995,17 +995,8 @@ name = "livekit-wakeword"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "huggingface-hub" },
     { name = "numpy" },
     { name = "onnxruntime" },
-    { name = "pyaudio" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
-    { name = "rich" },
-    { name = "soundfile" },
-    { name = "torch" },
-    { name = "torchaudio" },
-    { name = "typer" },
 ]
 
 [package.optional-dependencies]
@@ -1024,17 +1015,28 @@ export = [
     { name = "onnxruntime" },
     { name = "onnxscript" },
 ]
+listener = [
+    { name = "pyaudio" },
+]
 train = [
     { name = "audiomentations" },
     { name = "cmudict" },
+    { name = "huggingface-hub" },
     { name = "librosa" },
     { name = "nltk" },
     { name = "pronouncing" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "rich" },
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "setuptools" },
+    { name = "soundfile" },
+    { name = "torch" },
     { name = "torch-audiomentations" },
+    { name = "torchaudio" },
     { name = "tqdm" },
+    { name = "typer" },
     { name = "webrtcvad" },
 ]
 
@@ -1042,7 +1044,7 @@ train = [
 requires-dist = [
     { name = "audiomentations", marker = "extra == 'train'", specifier = ">=0.36" },
     { name = "cmudict", marker = "extra == 'train'", specifier = ">=1.0" },
-    { name = "huggingface-hub", specifier = ">=0.20" },
+    { name = "huggingface-hub", marker = "extra == 'train'", specifier = ">=0.20" },
     { name = "librosa", marker = "extra == 'train'", specifier = ">=0.10" },
     { name = "matplotlib", marker = "extra == 'eval'", specifier = ">=3.8" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
@@ -1053,26 +1055,26 @@ requires-dist = [
     { name = "onnxruntime", marker = "extra == 'export'", specifier = ">=1.17" },
     { name = "onnxscript", marker = "extra == 'export'", specifier = ">=0.6.2" },
     { name = "pronouncing", marker = "extra == 'train'", specifier = ">=0.2" },
-    { name = "pyaudio", specifier = ">=0.2.14" },
-    { name = "pydantic", specifier = ">=2.0" },
+    { name = "pyaudio", marker = "extra == 'listener'", specifier = ">=0.2.14" },
+    { name = "pydantic", marker = "extra == 'train'", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
-    { name = "pyyaml", specifier = ">=6.0" },
-    { name = "rich", specifier = ">=13.0" },
+    { name = "pyyaml", marker = "extra == 'train'", specifier = ">=6.0" },
+    { name = "rich", marker = "extra == 'train'", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "scikit-learn", marker = "extra == 'train'", specifier = ">=1.3" },
     { name = "scipy", marker = "extra == 'train'", specifier = ">=1.11" },
     { name = "setuptools", marker = "extra == 'train'", specifier = ">=69.0,<81" },
-    { name = "soundfile", specifier = ">=0.12" },
-    { name = "torch", specifier = ">=2.2" },
+    { name = "soundfile", marker = "extra == 'train'", specifier = ">=0.12" },
+    { name = "torch", marker = "extra == 'train'", specifier = ">=2.2" },
     { name = "torch-audiomentations", marker = "extra == 'train'", specifier = ">=0.11" },
-    { name = "torchaudio", specifier = ">=2.2" },
+    { name = "torchaudio", marker = "extra == 'train'", specifier = ">=2.2" },
     { name = "tqdm", marker = "extra == 'train'", specifier = ">=4.60" },
-    { name = "typer", specifier = ">=0.12" },
+    { name = "typer", marker = "extra == 'train'", specifier = ">=0.12" },
     { name = "webrtcvad", marker = "extra == 'train'", specifier = ">=2.0.10" },
 ]
-provides-extras = ["train", "eval", "export", "dev"]
+provides-extras = ["listener", "train", "eval", "export", "dev"]
 
 [[package]]
 name = "llvmlite"

--- a/uv.lock
+++ b/uv.lock
@@ -1000,13 +1000,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-dev = [
-    { name = "mypy" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "ruff" },
-]
 eval = [
     { name = "matplotlib" },
 ]
@@ -1040,6 +1033,15 @@ train = [
     { name = "webrtcvad" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "audiomentations", marker = "extra == 'train'", specifier = ">=0.36" },
@@ -1047,7 +1049,6 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'train'", specifier = ">=0.20" },
     { name = "librosa", marker = "extra == 'train'", specifier = ">=0.10" },
     { name = "matplotlib", marker = "extra == 'eval'", specifier = ">=3.8" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
     { name = "nltk", marker = "extra == 'train'", specifier = ">=3.8" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "onnx", marker = "extra == 'export'", specifier = ">=1.15" },
@@ -1057,12 +1058,8 @@ requires-dist = [
     { name = "pronouncing", marker = "extra == 'train'", specifier = ">=0.2" },
     { name = "pyaudio", marker = "extra == 'listener'", specifier = ">=0.2.14" },
     { name = "pydantic", marker = "extra == 'train'", specifier = ">=2.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pyyaml", marker = "extra == 'train'", specifier = ">=6.0" },
     { name = "rich", marker = "extra == 'train'", specifier = ">=13.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "scikit-learn", marker = "extra == 'train'", specifier = ">=1.3" },
     { name = "scipy", marker = "extra == 'train'", specifier = ">=1.11" },
     { name = "setuptools", marker = "extra == 'train'", specifier = ">=69.0,<81" },
@@ -1074,7 +1071,16 @@ requires-dist = [
     { name = "typer", marker = "extra == 'train'", specifier = ">=0.12" },
     { name = "webrtcvad", marker = "extra == 'train'", specifier = ">=2.0.10" },
 ]
-provides-extras = ["listener", "train", "eval", "export", "dev"]
+provides-extras = ["listener", "train", "eval", "export"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.8" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "pytest-cov", specifier = ">=4.0" },
+    { name = "ruff", specifier = ">=0.4" },
+]
 
 [[package]]
 name = "llvmlite"


### PR DESCRIPTION
## Summary
- Add PyPI metadata (readme, author, keywords, classifiers, project URLs)
- Slim core dependencies to `numpy` + `onnxruntime` for inference-only installs (~50MB vs ~2GB)
- Move `torch`, `pydantic`, `typer`, and other training deps to `[train]` extra
- Add `[listener]` extra for `pyaudio` (requires system portaudio)
- Lazy-load training/config imports in `__init__.py` so the inference API works without torch
- Move dev tools to PEP 735 `[dependency-groups]` so `uv run pytest` works without `--all-extras`

Install patterns after publish:
```bash
pip install livekit-wakeword              # inference only
pip install livekit-wakeword[listener]    # + microphone support
pip install livekit-wakeword[train]       # + full training pipeline
```

## Test plan
- [x] All 53 tests pass
- [x] Eager imports (`WakeWordModel`, `WakeWordListener`, `Detection`) work with only numpy + onnxruntime
- [x] Lazy imports (`WakeWordConfig`, `run_train`, `run_export`, etc.) resolve correctly when training deps are available
- [ ] `uv run pytest` works after a bare `uv sync`
- [ ] Test build with `uv build` and inspect wheel contents
- [ ] Test publish to TestPyPI before real PyPI