### PR TITLE
Fix broken logo on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <a href="https://livekit.io/">
-  <img src="./.github/assets/livekit-mark.png" alt="LiveKit logo" width="100" height="100">
+  <img src="https://raw.githubusercontent.com/livekit/livekit-wakeword/main/.github/assets/livekit-mark.png" alt="LiveKit logo" width="100" height="100">
 </a>
 
 # livekit-wakeword


### PR DESCRIPTION
## Summary
- Use absolute GitHub raw URL for the logo image in README
- PyPI doesn't resolve relative paths, so the logo was broken on the package page

## Test plan
- [ ] Verify logo renders on the PyPI package page after next publish