### PR TITLE
Add CI publish workflow with git-tag versioning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Build package
+        run: uv build
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "livekit-wakeword"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Wake word detection for voice-enabled applications"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -68,6 +68,12 @@ Issues = "https://github.com/livekit/livekit-wakeword/issues"
 
 [project.scripts]
 livekit-wakeword = "livekit.wakeword.cli:app"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/livekit/wakeword/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/livekit"]


### PR DESCRIPTION
## Summary
- Add `publish.yml` workflow that triggers on `v*` tag pushes and publishes to PyPI via trusted publishers (OIDC)
- Switch from hardcoded `version = "0.1.0"` to `hatch-vcs` so version is derived from git tags automatically

## Setup required
- Add a trusted publisher on pypi.org (owner: `livekit`, repo: `livekit-wakeword`, workflow: `publish.yml`, environment: `pypi`)
- Create a `pypi` environment in GitHub repo settings