### PR TITLE
Fix torch import error on inference-only installs

### DIFF
--- a/src/livekit/wakeword/models/__init__.py
+++ b/src/livekit/wakeword/models/__init__.py
@@ -1,8 +1,28 @@
 """Neural network models for wake word detection."""
 
-from .classifier import DNNClassifier, FCNBlock, RNNClassifier, build_classifier
+# Feature extractors use ONNX only — safe to import eagerly.
 from .feature_extractor import MelSpectrogramFrontend, SpeechEmbedding
-from .pipeline import WakeWordClassifier
+
+# Classifier / pipeline modules require torch and are lazy-loaded so that the
+# inference-only path (numpy + onnxruntime) works without torch installed.
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "DNNClassifier": (".classifier", "DNNClassifier"),
+    "FCNBlock": (".classifier", "FCNBlock"),
+    "RNNClassifier": (".classifier", "RNNClassifier"),
+    "build_classifier": (".classifier", "build_classifier"),
+    "WakeWordClassifier": (".pipeline", "WakeWordClassifier"),
+}
+
+
+def __getattr__(name: str) -> object:
+    if name in _LAZY_IMPORTS:
+        import importlib
+
+        module_path, attr = _LAZY_IMPORTS[name]
+        mod = importlib.import_module(module_path, __name__)
+        return getattr(mod, attr)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "DNNClassifier",


### PR DESCRIPTION
## Summary
- `models/__init__.py` eagerly imported `classifier` and `pipeline`, both of which `import torch` at the top level
- This caused `ModuleNotFoundError: No module named 'torch'` for users who only installed the core package (numpy + onnxruntime) for inference
- Lazy-load these torch-dependent modules via `__getattr__`, matching the pattern already used in the top-level `__init__.py`

## Test plan
- [x] All 53 tests pass
- [x] Verified `from livekit.wakeword import WakeWordListener, WakeWordModel` works without torch installed