### PR TITLE
Remove torchaudio fallback from MelSpectrogramFrontend

### DIFF
--- a/src/livekit/wakeword/models/feature_extractor.py
+++ b/src/livekit/wakeword/models/feature_extractor.py
@@ -5,8 +5,6 @@ The original openWakeWord pipeline uses two frozen ONNX models:
 2. embedding_model.onnx — Google's speech_embedding CNN (~330k params)
 
 We use ONNX runtime for both to guarantee output compatibility.
-A pure-torchaudio fallback is provided for the mel stage when the ONNX model
-is unavailable (e.g., during development/testing).
 """
 
 from __future__ import annotations
@@ -30,18 +28,13 @@ class MelSpectrogramFrontend:
     Output: (batch, time_frames, 32)
     """
 
-    def __init__(self, onnx_path: str | Path | None = None):
-        self._onnx_session = None
-        self._torch_frontend = None
-
-        if onnx_path is not None and Path(onnx_path).exists():
-            self._init_onnx(onnx_path)
-        else:
-            if onnx_path is not None:
-                logger.warning(
-                    f"Mel ONNX model not found at {onnx_path}, using torchaudio fallback"
-                )
-            self._init_torch_fallback()
+    def __init__(self, onnx_path: str | Path):
+        if not Path(onnx_path).exists():
+            raise FileNotFoundError(
+                f"Mel ONNX model not found: {onnx_path}\n"
+                "This should not happen - please reinstall livekit-wakeword."
+            )
+        self._init_onnx(onnx_path)
 
     def _init_onnx(self, onnx_path: str | Path) -> None:
         import onnxruntime as ort
@@ -53,25 +46,6 @@ class MelSpectrogramFrontend:
         self._input_name = self._onnx_session.get_inputs()[0].name
         logger.info(f"Loaded mel ONNX model from {onnx_path}")
 
-    def _init_torch_fallback(self) -> None:
-        """Initialize torchaudio fallback with parameters matching the ONNX model."""
-        import torch
-        import torchaudio.transforms as T
-
-        self._mel_spec = T.MelSpectrogram(
-            sample_rate=16000,
-            n_mels=32,
-            n_fft=512,
-            hop_length=160,
-            win_length=400,
-            f_min=60.0,
-            f_max=3800.0,
-            center=False,
-            power=2.0,
-        )
-        self._amplitude_to_db = T.AmplitudeToDB(stype="power", top_db=80.0)
-        logger.info("Using torchaudio mel fallback (close but not exact match to ONNX)")
-
     def __call__(self, audio: np.ndarray) -> np.ndarray:
         """Compute mel spectrogram features.
 
@@ -81,10 +55,7 @@ class MelSpectrogramFrontend:
         Returns:
             (batch, time_frames, 32) normalized mel features
         """
-        if self._onnx_session is not None:
-            return self._forward_onnx(audio)
-        else:
-            return self._forward_torch(audio)
+        return self._forward_onnx(audio)
 
     def _forward_onnx(self, audio: np.ndarray) -> np.ndarray:
         """Run ONNX mel model + post-processing normalization."""
@@ -106,24 +77,6 @@ class MelSpectrogramFrontend:
         # Post-processing: x/10 + 2 (matches openWakeWord's melspec_transform)
         mel = mel / 10.0 + 2.0
         return mel
-
-    def _forward_torch(self, audio: np.ndarray) -> np.ndarray:
-        """Torchaudio fallback with matched parameters."""
-        import torch
-
-        if audio.ndim == 1:
-            audio = audio[np.newaxis, :]
-
-        x = torch.from_numpy(audio)
-        # (batch, n_mels, time_frames)
-        mel = self._mel_spec(x)
-        # power_to_db: 10 * log10(mel) with top_db=80 clipping
-        mel_db = self._amplitude_to_db(mel)
-        # Transpose to (batch, time_frames, n_mels) and normalize
-        mel_db = mel_db.transpose(1, 2)
-        mel_db = mel_db / 10.0 + 2.0
-        return mel_db.numpy()
-
 
 class SpeechEmbedding:
     """Stage 2: Google's speech_embedding CNN via ONNX runtime.

--- a/tests/test_feature_extractor.py
+++ b/tests/test_feature_extractor.py
@@ -6,13 +6,14 @@ import numpy as np
 import pytest
 
 from livekit.wakeword.models.feature_extractor import MelSpectrogramFrontend
+from livekit.wakeword.resources import get_mel_model_path
 
 
-class TestMelSpectrogramFrontendFallback:
-    """Test the torchaudio fallback (no ONNX model available)."""
+class TestMelSpectrogramFrontend:
+    """Test the ONNX mel spectrogram frontend."""
 
     def test_output_shape(self):
-        frontend = MelSpectrogramFrontend(onnx_path=None)
+        frontend = MelSpectrogramFrontend(onnx_path=get_mel_model_path())
         audio = np.random.randn(2, 32000).astype(np.float32)
         mel = frontend(audio)
         batch, time_frames, n_mels = mel.shape
@@ -21,18 +22,16 @@ class TestMelSpectrogramFrontendFallback:
         assert time_frames > 0
 
     def test_single_sample(self):
-        frontend = MelSpectrogramFrontend(onnx_path=None)
+        frontend = MelSpectrogramFrontend(onnx_path=get_mel_model_path())
         audio = np.random.randn(1, 16000).astype(np.float32)  # 1 second
         mel = frontend(audio)
         assert mel.shape[0] == 1
         assert mel.shape[2] == 32
-        # 16000 samples, center=False, hop=160, win=400:
-        # floor((16000 - 400) / 160) + 1 = 98
         assert mel.shape[1] > 90
 
     def test_1d_input(self):
         """1D input should be auto-batched."""
-        frontend = MelSpectrogramFrontend(onnx_path=None)
+        frontend = MelSpectrogramFrontend(onnx_path=get_mel_model_path())
         audio = np.random.randn(16000).astype(np.float32)
         mel = frontend(audio)
         assert mel.ndim == 3
@@ -40,15 +39,13 @@ class TestMelSpectrogramFrontendFallback:
         assert mel.shape[2] == 32
 
     def test_deterministic(self):
-        frontend = MelSpectrogramFrontend(onnx_path=None)
+        frontend = MelSpectrogramFrontend(onnx_path=get_mel_model_path())
         audio = np.random.randn(1, 16000).astype(np.float32)
         mel1 = frontend(audio)
         mel2 = frontend(audio)
         np.testing.assert_allclose(mel1, mel2)
 
-    def test_nonexistent_onnx_falls_back(self, tmp_path):
-        """Non-existent ONNX path should fall back to torchaudio."""
-        frontend = MelSpectrogramFrontend(onnx_path=tmp_path / "nonexistent.onnx")
-        audio = np.random.randn(1, 16000).astype(np.float32)
-        mel = frontend(audio)
-        assert mel.shape[2] == 32
+    def test_nonexistent_onnx_raises(self, tmp_path):
+        """Non-existent ONNX path should raise FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            MelSpectrogramFrontend(onnx_path=tmp_path / "nonexistent.onnx")


### PR DESCRIPTION
## Summary
- Removed the torchaudio fallback path from `MelSpectrogramFrontend` — the ONNX mel model is bundled with the package so the fallback was never needed
- `onnx_path` is now required (no more `None` default), and missing paths raise `FileNotFoundError`
- Eliminates a hidden torch dependency lurking in the feature extractor

## Test plan
- [x] All 53 tests pass
- [x] Updated tests to use bundled ONNX model instead of `onnx_path=None`
- [x] Added test that missing ONNX path raises `FileNotFoundError`