### PR TITLE
Fix augmentation pipeline: stack rounds, preserve originals

### DIFF
--- a/docs/augmentation.md
+++ b/docs/augmentation.md
@@ -8,20 +8,22 @@ The augmentation stage applies realistic audio transformations to synthetic TTS 
 ## Overview
 
 ```
-Generated .wav clips
+Original TTS clips (clip_000000.wav)
     │
-    ├──► Per-sample augmentations (audiomentations)
-    │    EQ, distortion
-    │
+    ▼  Round 0: reads originals
+    ├──► Per-sample augmentations (EQ, distortion)
     ├──► RIR convolution
-    │    Room impulse responses
-    │
     ├──► Background mixing
-    │    Real-world noise at random SNR
-    │
     ├──► Alignment
-    │    Positive: end-of-window
-    │    Negative: center-padded
+    └──► clip_000000_r0.wav
+              │
+              ▼  Round 1: reads r0 output (stacks)
+              ├──► Per-sample augmentations
+              ├──► RIR convolution
+              ├──► Background mixing
+              └──► clip_000000_r1.wav
+                        │
+                        ▼  ... Round N reads r(N-1)
 ```
 
 ## AudioAugmentor
@@ -55,7 +57,7 @@ Applied via the `audiomentations` library to individual clips:
 
 ### Background Mixing
 
-`mix_with_background(audio, snr_db_range=(5.0, 15.0))` mixes audio with a random background noise clip at a randomly selected SNR within the given range. The batch augmentations use an SNR range of **0–15 dB** for `AddBackgroundNoise` (signal is always at least as loud as the noise).
+`mix_with_background(audio, snr_db_range=(5.0, 15.0))` mixes audio with a random background noise clip at a randomly selected SNR within the given range.
 
 The background clip is looped (tiled) if shorter than the audio and randomly cropped to a starting position. The mixing formula scales the background based on:
 
@@ -87,9 +89,9 @@ Negative clips are centered within the target window. If longer than the target,
 
 ## Augmentation Rounds
 
-The augmentation pipeline runs `config.augmentation.rounds` passes over all four directories (positive train/test, negative train/test). Round 0 overwrites the original `.wav` files in-place. Subsequent rounds write new files (e.g. `clip_000000_r1.wav`) but read from the round-0 (already augmented) files, not the raw TTS output.
+The augmentation pipeline runs `config.augmentation.rounds` passes over all four directories (positive train/test, negative train/test). Each round writes to a separate file (`clip_000000_r0.wav`, `clip_000000_r1.wav`, etc.) — originals are never modified.
 
-Only original clips (`clip_######.wav`) are read as input — augmented variants (`clip_000000_r1.wav`, etc.) are excluded via a regex filter to prevent compounding augmentation effects across rounds.
+Rounds **stack**: round 0 reads the clean TTS originals, round 1 reads round 0's output, round 2 reads round 1's output, and so on. This produces progressively more degraded audio as augmentation effects compound across rounds. Old augmented files (`_rN.wav`) are cleaned up at the start of each run so re-running is idempotent.
 
 ## Per-Clip Processing Order
 
@@ -99,8 +101,8 @@ For each WAV file in a directory:
 2. Apply per-sample augmentations (EQ, distortion)
 3. Apply RIR convolution (50% probability)
 4. Mix with background noise
-5. Align to window (end-aligned for positives, center-padded for negatives)
-6. Write back to the same file path
+5. Align to window — round 0 only (end-aligned for positives, center-padded for negatives)
+6. Write to `clip_NNNNNN_r{round}.wav` (originals preserved)
 
 ## Output
 
@@ -108,10 +110,16 @@ After augmentation:
 
 ```
 output/<model_name>/
-├── positive_train/                 # Augmented .wav files
+├── positive_train/
+│   ├── clip_000000.wav             # Original TTS (preserved, not used for training)
+│   ├── clip_000000_r0.wav          # Round 0 augmented
+│   ├── clip_000000_r1.wav          # Round 1 (stacked on r0)
+│   └── ...
 ├── positive_test/
 ├── negative_train/
 └── negative_test/
 ```
+
+Only `_rN.wav` files are fed to feature extraction — clean TTS originals are excluded from training since they don't match real microphone audio.
 
 Feature extraction is a separate step — see [Feature Extraction](feature-extraction.md).

--- a/docs/feature-extraction.md
+++ b/docs/feature-extraction.md
@@ -200,6 +200,8 @@ Left-padding places zeros at the **beginning** of the sequence, so the real audi
 
 Each `.npy` file contains a float32 array of shape `(N_clips, 16, 96)`.
 
+Only augmented clips (`clip_NNNNNN_rN.wav`) are processed — clean TTS originals are excluded via a regex filter so that training data always reflects realistic augmented audio.
+
 Audio files are read via `soundfile`, converted to float32, reduced to mono if stereo, and processed one clip at a time.
 
 ## Memory-Mapped Dataset

--- a/src/livekit/wakeword/data/augment.py
+++ b/src/livekit/wakeword/data/augment.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-import torch
 
 from ..config import WakeWordConfig
 
@@ -18,7 +17,7 @@ logger = logging.getLogger(__name__)
 class AudioAugmentor:
     """Augmentation pipeline for wake word clips.
 
-    Applies per-sample and batched augmentations, RIR convolution,
+    Applies per-sample augmentations, RIR convolution,
     and background noise mixing.
     """
 
@@ -32,7 +31,6 @@ class AudioAugmentor:
         self.background_files = self._collect_wavs(background_paths)
         self.rir_files = self._collect_wavs(rir_paths)
         self._per_sample_aug = None
-        self._batch_aug = None
 
     @staticmethod
     def _collect_wavs(dirs: list[Path]) -> list[Path]:
@@ -55,48 +53,6 @@ class AudioAugmentor:
             )
         return self._per_sample_aug
 
-    def _get_batch_augmentations(self) -> Any:
-        """Lazy-load torch-audiomentations transforms."""
-        if self._batch_aug is None:
-            from torch_audiomentations import (
-                AddBackgroundNoise,
-                AddColoredNoise,
-                BandStopFilter,
-                Compose,
-                Gain,
-                PitchShift,
-            )
-
-            transforms = [
-                PitchShift(
-                    min_transpose_semitones=-3.0,
-                    max_transpose_semitones=3.0,
-                    sample_rate=self.sample_rate,
-                    p=0.25,
-                ),
-                BandStopFilter(p=0.25),
-                AddColoredNoise(p=0.25),
-                Gain(
-                    min_gain_in_db=-6.0,
-                    max_gain_in_db=6.0,
-                    p=0.5,
-                ),
-            ]
-            if self.background_files:
-                # Collect all unique parent directories containing background audio
-                bg_dirs = list({str(p.parent) for p in self.background_files})
-                transforms.insert(
-                    3,
-                    AddBackgroundNoise(
-                        background_paths=bg_dirs,
-                        min_snr_in_db=0.0,
-                        max_snr_in_db=15.0,
-                        sample_rate=self.sample_rate,
-                        p=0.75,
-                    ),
-                )
-            self._batch_aug = Compose(transforms)
-        return self._batch_aug
 
     def apply_rir(self, audio: np.ndarray, p: float = 0.5) -> np.ndarray:
         """Convolve audio with a random room impulse response."""
@@ -118,18 +74,6 @@ class AudioAugmentor:
         """Apply per-sample augmentations to a single clip."""
         aug = self._get_per_sample_augmentations()
         return aug(samples=audio, sample_rate=self.sample_rate)
-
-    def augment_batch(self, batch: torch.Tensor) -> torch.Tensor:
-        """Apply batched augmentations.
-
-        Args:
-            batch: (batch, 1, samples) tensor
-
-        Returns:
-            (batch, 1, samples) augmented tensor
-        """
-        aug = self._get_batch_augmentations()
-        return aug(batch, sample_rate=self.sample_rate).samples
 
     def mix_with_background(
         self,
@@ -232,20 +176,29 @@ def _augment_directory(
 ) -> None:
     """Augment all WAV files in a directory.
 
-    All rounds write to separate files (e.g. ``clip_000000_r0.wav``),
-    preserving the original TTS clips. This ensures re-running
-    augmentation doesn't compound noise on already-augmented audio.
+    Round 0 reads the original TTS clips (``clip_000000.wav``).
+    Subsequent rounds read the previous round's output so that
+    augmentation compounds (stacks) progressively.  Every round
+    writes to its own file (``clip_000000_r0.wav``, ``_r1.wav``, …)
+    so the originals are always preserved.
     """
+    import re
+
     import soundfile as sf
     from tqdm import tqdm
 
     target_length = int(target_duration_s * sample_rate)
-    # Only read original clips (clip_000000.wav) — exclude augmented variants (clip_000000_r1.wav)
-    import re
-    _orig_re = re.compile(r"^clip_\d{6}\.wav$")
-    wav_files = sorted(p for p in clip_dir.glob("*.wav") if _orig_re.match(p.name))
 
-    for wav_path in tqdm(wav_files, desc=f"Augmenting {clip_dir.name}", unit="clip"):
+    if round_idx == 0:
+        # Round 0: read original TTS clips
+        _src_re = re.compile(r"^clip_\d{6}\.wav$")
+    else:
+        # Round N: read previous round's output
+        _src_re = re.compile(rf"^clip_\d{{6}}_r{round_idx - 1}\.wav$")
+
+    wav_files = sorted(p for p in clip_dir.glob("*.wav") if _src_re.match(p.name))
+
+    for wav_path in tqdm(wav_files, desc=f"Augmenting {clip_dir.name} r{round_idx}", unit="clip"):
         audio, sr = sf.read(str(wav_path))
         if audio.ndim > 1:
             audio = audio[:, 0]
@@ -260,19 +213,23 @@ def _augment_directory(
         # Mix with background
         audio = augmentor.mix_with_background(audio)
 
-        # Align positive clips to end of window
-        if is_positive:
-            audio = align_clip_to_end(audio, target_length)
-        else:
-            # Center-pad or crop negatives
-            if len(audio) < target_length:
-                padded = np.zeros(target_length, dtype=np.float32)
-                start = (target_length - len(audio)) // 2
-                padded[start : start + len(audio)] = audio
-                audio = padded
-            elif len(audio) > target_length:
-                start = (len(audio) - target_length) // 2
-                audio = audio[start : start + target_length]
+        # Align to target duration only on round 0 (raw TTS clips vary in
+        # length).  Later rounds already have the correct duration.
+        if round_idx == 0:
+            if is_positive:
+                audio = align_clip_to_end(audio, target_length)
+            else:
+                # Center-pad or crop negatives
+                if len(audio) < target_length:
+                    padded = np.zeros(target_length, dtype=np.float32)
+                    start = (target_length - len(audio)) // 2
+                    padded[start : start + len(audio)] = audio
+                    audio = padded
+                elif len(audio) > target_length:
+                    start = (len(audio) - target_length) // 2
+                    audio = audio[start : start + target_length]
 
-        out_path = wav_path.with_name(f"{wav_path.stem}_r{round_idx}.wav")
+        # Derive output name from the original stem (strip any _rN suffix)
+        orig_stem = re.sub(r"_r\d+$", "", wav_path.stem)
+        out_path = wav_path.with_name(f"{orig_stem}_r{round_idx}.wav")
         sf.write(str(out_path), audio, sample_rate)

--- a/src/livekit/wakeword/data/features.py
+++ b/src/livekit/wakeword/data/features.py
@@ -38,10 +38,14 @@ def extract_features_from_directory(
     Processes clips through MelSpectrogramFrontend → SpeechEmbedding,
     then takes last 16 embedding timesteps per clip.
     """
+    import re
+
     import soundfile as sf
     from tqdm import tqdm
 
-    wav_files = sorted(clip_dir.glob("*.wav"))
+    # Only process augmented clips (_rN.wav), skip clean TTS originals
+    _aug_re = re.compile(r"^clip_\d{6}_r\d+\.wav$")
+    wav_files = sorted(p for p in clip_dir.glob("*.wav") if _aug_re.match(p.name))
     if not wav_files:
         logger.warning(f"No WAV files in {clip_dir}")
         return np.zeros((0, N_EMBEDDING_TIMESTEPS, 96), dtype=np.float32)

--- a/uv.lock
+++ b/uv.lock
@@ -992,7 +992,6 @@ wheels = [
 
 [[package]]
 name = "livekit-wakeword"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },
@@ -1071,7 +1070,7 @@ requires-dist = [
     { name = "typer", marker = "extra == 'train'", specifier = ">=0.12" },
     { name = "webrtcvad", marker = "extra == 'train'", specifier = ">=2.0.10" },
 ]
-provides-extras = ["listener", "train", "eval", "export"]
+provides-extras = ["eval", "export", "listener", "train"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- **Stack rounds**: Round N reads round N-1's output instead of the original, so augmentation effects compound progressively (EQ → RIR → noise layers build up across rounds)
- **Preserve originals**: All rounds write to `_rN.wav` files; TTS originals are never overwritten. Old augmented files are cleaned at the start of each run for idempotency
- **Exclude clean TTS from training**: Feature extraction only processes `_rN.wav` files — clean TTS originals are skipped since they don't match real microphone audio
- **Round 0-only alignment**: End-align (positives) and center-pad (negatives) restricted to round 0 to prevent progressive shifting in later rounds
- **Remove dead code**: `augment_batch`, `_get_batch_augmentations`, `_batch_aug` field, and `torch` import (unused since initial commit)
- **Update docs**: `augmentation.md` and `feature-extraction.md` updated to reflect all changes

## Test plan
- [x] All 53 existing tests pass
- [x] Run full pipeline (`livekit-wakeword run`) with `rounds: 1` and verify only `_r0.wav` files are created alongside preserved originals
- [x] Run with `rounds: 3` and verify `_r0`, `_r1`, `_r2` files exist with progressively more degraded audio
- [x] Verify feature extraction `.npy` shapes match expected clip count (augmented only, no originals)
- [x] Re-run augmentation and confirm old `_rN.wav` files are cleaned before new ones are written