### PR TITLE
docs: bump README version badge to v0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/livekit/livekit-wakeword/actions/workflows/ci.yml/badge.svg)](https://github.com/livekit/livekit-wakeword/actions/workflows/ci.yml)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-v0.1-green)](https://github.com/livekit/livekit-wakeword)
+[![Version](https://img.shields.io/badge/version-v0.2-green)](https://github.com/livekit/livekit-wakeword)
 
 An open-source wake word library for creating voice-enabled applications. Based on [openWakeWord](https://github.com/dscripka/openWakeWord) with streamlined training: generate synthetic data, augment, train, and export from a single YAML config.
 


### PR DESCRIPTION
## Summary

Bump the README version badge from `v0.1` to `v0.2` ahead of cutting the v0.2.0 release (VoxCPM2 multilingual TTS backend + Rust inference docs).

The Python package version itself is derived from git tags via hatch-vcs (`[tool.hatch.version] source = "vcs"`), so this is purely cosmetic: it keeps the shields.io badge consistent with the upcoming `v0.2.0` tag.

## Test plan

- [ ] Render README on GitHub and confirm the green Version badge reads `v0.2`.
- [ ] After this merges, tag `v0.2.0` on the merge commit and push the tag to trigger the Publish workflow.