### PR TITLE
feat: auto-select ONNX Runtime providers (CUDA / CPU) for training, eval, and inference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --extra train --extra export
+        run: uv sync --extra cpu --extra train --extra export
 
       - name: Run tests
         run: uv run pytest --tb=short -q

--- a/README.md
+++ b/README.md
@@ -264,6 +264,22 @@ cd livekit-wakeword
 uv sync --all-extras
 ```
 
+**GPU acceleration (training, eval, and inference):**
+
+The default `onnxruntime` wheel is CPU-only — on a GPU pod this makes feature extraction the pipeline bottleneck. To unlock the CUDA Execution Provider, install the `gpu` extra:
+
+```bash
+# pip
+pip uninstall -y onnxruntime
+pip install livekit-wakeword[train,eval,export,gpu]
+
+# uv (from source)
+uv pip uninstall onnxruntime
+uv sync --extra train --extra eval --extra export --extra gpu
+```
+
+The `onnxruntime` and `onnxruntime-gpu` wheels provide the same Python module — pip cannot keep them side-by-side, so uninstall the CPU wheel before installing the GPU one. Provider selection is automatic (CUDA if available, CPU otherwise). Force a specific provider with `LIVEKIT_WAKEWORD_ORT_PROVIDERS=CPUExecutionProvider` (comma-separated; useful for reproducibility or opting into CoreML / DirectML / ROCm). `onnxruntime-gpu` requires a matching CUDA toolkit — see the [ONNX Runtime GPU compatibility matrix](https://onnxruntime.ai/docs/install/#cuda-and-cudnn).
+
 **Download models and data:**
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -118,16 +118,20 @@ sudo apt install portaudio19-dev
 
 **Installation:**
 
+livekit-wakeword needs an ONNX Runtime backend, installed via the `cpu` extra
+(CPU-only) or the `gpu` extra (CUDA — see [GPU acceleration](#gpu-acceleration)).
+Pick exactly one; they share the `onnxruntime` import path and cannot coexist.
+
 ```bash
-pip install livekit-wakeword
+pip install livekit-wakeword[cpu]
 # or
-uv add livekit-wakeword
+uv add "livekit-wakeword[cpu]"
 ```
 
-For microphone listening, install with the `listener` extra:
+For microphone listening, add the `listener` extra:
 
 ```bash
-pip install livekit-wakeword[listener]
+pip install livekit-wakeword[cpu,listener]
 ```
 
 **Basic inference:**
@@ -240,16 +244,18 @@ brew install espeak-ng ffmpeg portaudio
 sudo apt install espeak-ng libsndfile1 ffmpeg sox portaudio19-dev
 ```
 
+Add the `cpu` backend extra (or `gpu` — see [GPU acceleration](#gpu-acceleration)) alongside the training extras.
+
 **Installation (with pip):**
 
 ```bash
-pip install livekit-wakeword[train,eval,export]
+pip install livekit-wakeword[cpu,train,eval,export]
 ```
 
 **Installation (with uv):**
 
 ```bash
-uv tool install livekit-wakeword[train,eval,export]
+uv tool install "livekit-wakeword[cpu,train,eval,export]"
 ```
 
 **Installation (from source):**
@@ -258,27 +264,28 @@ uv tool install livekit-wakeword[train,eval,export]
 # Install uv (if you don't have it)
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# Clone and install
+# Clone and install (pick the cpu OR gpu backend — they're mutually exclusive)
 git clone https://github.com/livekit/livekit-wakeword
 cd livekit-wakeword
-uv sync --all-extras
+uv sync --extra cpu --extra train --extra eval --extra export
 ```
 
+<a id="gpu-acceleration"></a>
 **GPU acceleration (training, eval, and inference):**
 
-The default `onnxruntime` wheel is CPU-only — on a GPU pod this makes feature extraction the pipeline bottleneck. To unlock the CUDA Execution Provider, install the `gpu` extra:
+The `cpu` extra is CPU-only — on a GPU pod this makes feature extraction the pipeline bottleneck (a production augmentation run takes ~14 h on CPU vs ~13 min on an RTX 3090). Swap in the `gpu` extra to unlock the CUDA Execution Provider:
 
 ```bash
 # pip
-pip uninstall -y onnxruntime
-pip install livekit-wakeword[train,eval,export,gpu]
+pip install livekit-wakeword[gpu,train,eval,export]
 
 # uv (from source)
-uv pip uninstall onnxruntime
-uv sync --extra train --extra eval --extra export --extra gpu
+uv sync --extra gpu --extra train --extra eval --extra export
 ```
 
-The `onnxruntime` and `onnxruntime-gpu` wheels provide the same Python module — pip cannot keep them side-by-side, so uninstall the CPU wheel before installing the GPU one. Provider selection is automatic (CUDA if available, CPU otherwise). Force a specific provider with `LIVEKIT_WAKEWORD_ORT_PROVIDERS=CPUExecutionProvider` (comma-separated; useful for reproducibility or opting into CoreML / DirectML / ROCm). `onnxruntime-gpu` requires a matching CUDA toolkit — see the [ONNX Runtime GPU compatibility matrix](https://onnxruntime.ai/docs/install/#cuda-and-cudnn).
+Provider selection is then automatic (CUDA if available, CPU otherwise). Force a specific provider with `LIVEKIT_WAKEWORD_ORT_PROVIDERS=CPUExecutionProvider` (comma-separated; useful for reproducibility or opting into CoreML / DirectML / ROCm). `onnxruntime-gpu` requires a matching CUDA toolkit — see the [ONNX Runtime GPU compatibility matrix](https://onnxruntime.ai/docs/install/#cuda-and-cudnn).
+
+> **Switching an existing install** between `cpu` and `gpu`: the `onnxruntime` and `onnxruntime-gpu` wheels share the same `onnxruntime` import path and cannot coexist, so remove the old one first (`pip uninstall -y onnxruntime onnxruntime-gpu`, then reinstall with the desired extra). With `uv`, `[tool.uv].conflicts` enforces this automatically when you `uv sync` a different backend extra from this repo.
 
 **Download models and data:**
 
@@ -355,7 +362,7 @@ tts_backend: voxcpm
 And install `livekit-wakeword` with the `voxcpm` optional dependency:
 
 ```bash
-pip install livekit-wakeword[train,eval,export,voxcpm]
+pip install livekit-wakeword[cpu,train,eval,export,voxcpm]
 ```
 
 > [!WARNING]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,18 @@ classifiers = [
 
 dependencies = [
     "numpy>=1.24",
-    "onnxruntime>=1.17",
 ]
 
 [project.optional-dependencies]
+# ONNX Runtime backend — pick exactly one. Kept out of base deps because
+# `onnxruntime` and `onnxruntime-gpu` share the `onnxruntime` import path and
+# clobber each other on disk if both are installed (see [tool.uv] conflicts).
+cpu = [
+    "onnxruntime>=1.20",
+]
+gpu = [
+    "onnxruntime-gpu>=1.20",
+]
 listener = [
     "pyaudio>=0.2.14",
 ]
@@ -61,11 +69,7 @@ eval = [
 ]
 export = [
     "onnx>=1.15",
-    "onnxruntime>=1.17",
     "onnxscript>=0.6.2",
-]
-gpu = [
-    "onnxruntime-gpu>=1.17",
 ]
 [project.urls]
 Homepage = "https://github.com/livekit/livekit-wakeword"
@@ -97,6 +101,12 @@ include = [
     "src/livekit/wakeword/**/*.py",
     "src/livekit/wakeword/resources/*.onnx",
 ]
+
+[tool.uv]
+# cpu/gpu both provide the onnxruntime import path — never resolve them together.
+# NOTE: this is honored when developing in this repo (`uv sync --extra gpu`), but
+# does NOT propagate to downstream consumers of the published wheel.
+conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]
 
 [dependency-groups]
 dev = ["pytest>=8.0", "pytest-cov>=4.0", "pytest-asyncio>=0.23", "ruff>=0.4", "mypy>=1.8"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ export = [
     "onnxruntime>=1.17",
     "onnxscript>=0.6.2",
 ]
+gpu = [
+    "onnxruntime-gpu>=1.17",
+]
 [project.urls]
 Homepage = "https://github.com/livekit/livekit-wakeword"
 Repository = "https://github.com/livekit/livekit-wakeword"

--- a/src/livekit/wakeword/__init__.py
+++ b/src/livekit/wakeword/__init__.py
@@ -5,8 +5,9 @@ from .inference.model import WakeWordModel
 
 __version__ = "0.1.0"
 
-# Training / CLI imports are lazy-loaded so that the core inference API
-# works with only numpy + onnxruntime (no torch, pydantic, etc.).
+# Training / CLI imports are lazy-loaded so that the core inference API works
+# with only numpy + an ONNX Runtime backend (the cpu/gpu extra; no torch,
+# pydantic, etc.).
 _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "WakeWordConfig": (".config", "WakeWordConfig"),
     "load_config": (".config", "load_config"),

--- a/src/livekit/wakeword/_ort_providers.py
+++ b/src/livekit/wakeword/_ort_providers.py
@@ -1,0 +1,54 @@
+"""Runtime selection of ONNX Runtime execution providers.
+
+Central helper used everywhere an ``ort.InferenceSession`` is created, so the
+provider list stays consistent across training (feature extraction), eval, and
+inference (``WakeWordModel``).
+
+Default behavior: prefer CUDA, fall back to CPU — driven by whatever ONNX
+Runtime distribution is installed (plain ``onnxruntime`` is CPU-only; install
+``onnxruntime-gpu`` to unlock CUDA, see README for the switch).
+
+Override via the ``LIVEKIT_WAKEWORD_ORT_PROVIDERS`` env var (comma-separated
+provider names) — handy for forcing CPU for reproducibility, or opting into
+less-common providers like CoreML / DirectML / ROCm / TensorRT.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+_logger = logging.getLogger(__name__)
+
+_DEFAULT_PREFERENCE: tuple[str, ...] = ("CUDAExecutionProvider", "CPUExecutionProvider")
+_ENV_VAR = "LIVEKIT_WAKEWORD_ORT_PROVIDERS"
+
+
+def get_providers() -> list[str]:
+    """Return the ONNX Runtime provider list to pass to ``InferenceSession``.
+
+    Resolution order:
+
+    1. If ``LIVEKIT_WAKEWORD_ORT_PROVIDERS`` is set and non-empty, parse it
+       as a comma-separated list and return verbatim.  ORT itself will reject
+       unknown providers at session-creation time with a clear error.
+    2. Otherwise intersect ``onnxruntime.get_available_providers()`` with
+       ``("CUDAExecutionProvider", "CPUExecutionProvider")`` in that order.
+    3. If neither preferred provider is available (unusual — e.g. a non-CPU
+       build without CUDA), return whatever ORT reports as available so
+       session creation still succeeds.
+    """
+    import onnxruntime as ort
+
+    override = os.environ.get(_ENV_VAR, "").strip()
+    if override:
+        providers = [p.strip() for p in override.split(",") if p.strip()]
+        _logger.info("ORT providers from %s: %s", _ENV_VAR, providers)
+        return providers
+
+    available = set(ort.get_available_providers())
+    providers = [p for p in _DEFAULT_PREFERENCE if p in available]
+    if not providers:
+        providers = list(ort.get_available_providers())
+    _logger.info("ORT providers (auto-selected): %s", providers)
+    return providers

--- a/src/livekit/wakeword/_ort_providers.py
+++ b/src/livekit/wakeword/_ort_providers.py
@@ -5,8 +5,9 @@ provider list stays consistent across training (feature extraction), eval, and
 inference (``WakeWordModel``).
 
 Default behavior: prefer CUDA, fall back to CPU — driven by whatever ONNX
-Runtime distribution is installed (plain ``onnxruntime`` is CPU-only; install
-``onnxruntime-gpu`` to unlock CUDA, see README for the switch).
+Runtime distribution is installed.  A backend is no longer a base dependency;
+install the ``cpu`` extra (``onnxruntime``) or the ``gpu`` extra
+(``onnxruntime-gpu``) to get one — see README for the switch.
 
 Override via the ``LIVEKIT_WAKEWORD_ORT_PROVIDERS`` env var (comma-separated
 provider names) — handy for forcing CPU for reproducibility, or opting into
@@ -17,11 +18,33 @@ from __future__ import annotations
 
 import logging
 import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 _logger = logging.getLogger(__name__)
 
 _DEFAULT_PREFERENCE: tuple[str, ...] = ("CUDAExecutionProvider", "CPUExecutionProvider")
 _ENV_VAR = "LIVEKIT_WAKEWORD_ORT_PROVIDERS"
+
+
+def import_ort() -> ModuleType:
+    """Import ``onnxruntime`` with an actionable error if no backend is installed.
+
+    livekit-wakeword does not bundle an ONNX Runtime backend — exactly one of the
+    ``cpu`` / ``gpu`` extras must be installed.
+    """
+    try:
+        import onnxruntime as ort
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "No ONNX Runtime backend is installed. livekit-wakeword does not bundle "
+            "one — install exactly one of:\n"
+            "  pip install 'livekit-wakeword[cpu]'   # CPU-only\n"
+            "  pip install 'livekit-wakeword[gpu]'   # CUDA (see README)"
+        ) from exc
+    return ort
 
 
 def get_providers() -> list[str]:
@@ -38,7 +61,7 @@ def get_providers() -> list[str]:
        build without CUDA), return whatever ORT reports as available so
        session creation still succeeds.
     """
-    import onnxruntime as ort
+    ort = import_ort()
 
     override = os.environ.get(_ENV_VAR, "").strip()
     if override:

--- a/src/livekit/wakeword/eval/evaluate.py
+++ b/src/livekit/wakeword/eval/evaluate.py
@@ -7,10 +7,11 @@ import logging
 from pathlib import Path
 
 import numpy as np
-import onnxruntime as ort
 
-from .._ort_providers import get_providers
+from .._ort_providers import get_providers, import_ort
 from ..config import WakeWordConfig
+
+ort = import_ort()
 
 logger = logging.getLogger(__name__)
 

--- a/src/livekit/wakeword/eval/evaluate.py
+++ b/src/livekit/wakeword/eval/evaluate.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import numpy as np
 import onnxruntime as ort
 
+from .._ort_providers import get_providers
 from ..config import WakeWordConfig
 
 logger = logging.getLogger(__name__)
@@ -194,7 +195,7 @@ def run_eval(config: WakeWordConfig, model_path: str | Path) -> dict[str, float]
     if not model_path.exists():
         raise FileNotFoundError(f"Model not found: {model_path}")
 
-    session = ort.InferenceSession(str(model_path), providers=["CPUExecutionProvider"])
+    session = ort.InferenceSession(str(model_path), providers=get_providers())
     logger.info(f"Loaded model from {model_path}")
 
     # Load validation data

--- a/src/livekit/wakeword/inference/model.py
+++ b/src/livekit/wakeword/inference/model.py
@@ -77,6 +77,8 @@ class WakeWordModel:
         """
         import onnxruntime as ort
 
+        from .._ort_providers import get_providers
+
         model_path = Path(model_path)
         if not model_path.exists():
             raise FileNotFoundError(f"Wake word model not found: {model_path}")
@@ -86,7 +88,7 @@ class WakeWordModel:
 
         session = ort.InferenceSession(
             str(model_path),
-            providers=["CPUExecutionProvider"],
+            providers=get_providers(),
         )
         input_name = session.get_inputs()[0].name
         self._classifiers[model_name] = (session, input_name)

--- a/src/livekit/wakeword/inference/model.py
+++ b/src/livekit/wakeword/inference/model.py
@@ -75,9 +75,9 @@ class WakeWordModel:
             model_path: Path to the ONNX wake word classifier.
             model_name: Optional name for the model. If None, derived from filename.
         """
-        import onnxruntime as ort
+        from .._ort_providers import get_providers, import_ort
 
-        from .._ort_providers import get_providers
+        ort = import_ort()
 
         model_path = Path(model_path)
         if not model_path.exists():

--- a/src/livekit/wakeword/models/feature_extractor.py
+++ b/src/livekit/wakeword/models/feature_extractor.py
@@ -16,6 +16,7 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
+
 class MelSpectrogramFrontend:
     """Stage 1: Raw audio → mel-spectrogram features.
 
@@ -39,9 +40,11 @@ class MelSpectrogramFrontend:
     def _init_onnx(self, onnx_path: str | Path) -> None:
         import onnxruntime as ort
 
+        from .._ort_providers import get_providers
+
         self._onnx_session = ort.InferenceSession(
             str(onnx_path),
-            providers=["CPUExecutionProvider"],
+            providers=get_providers(),
         )
         self._input_name = self._onnx_session.get_inputs()[0].name
         logger.info(f"Loaded mel ONNX model from {onnx_path}")
@@ -78,6 +81,7 @@ class MelSpectrogramFrontend:
         mel = mel / 10.0 + 2.0
         return mel
 
+
 class SpeechEmbedding:
     """Stage 2: Google's speech_embedding CNN via ONNX runtime.
 
@@ -92,6 +96,8 @@ class SpeechEmbedding:
     def __init__(self, onnx_path: str | Path):
         import onnxruntime as ort
 
+        from .._ort_providers import get_providers
+
         if not Path(onnx_path).exists():
             raise FileNotFoundError(
                 f"Embedding ONNX model not found: {onnx_path}\n"
@@ -100,7 +106,7 @@ class SpeechEmbedding:
 
         self._session = ort.InferenceSession(
             str(onnx_path),
-            providers=["CPUExecutionProvider"],
+            providers=get_providers(),
         )
         self._input_name = self._session.get_inputs()[0].name
         logger.info(f"Loaded embedding ONNX model from {onnx_path}")

--- a/src/livekit/wakeword/models/feature_extractor.py
+++ b/src/livekit/wakeword/models/feature_extractor.py
@@ -38,9 +38,9 @@ class MelSpectrogramFrontend:
         self._init_onnx(onnx_path)
 
     def _init_onnx(self, onnx_path: str | Path) -> None:
-        import onnxruntime as ort
+        from .._ort_providers import get_providers, import_ort
 
-        from .._ort_providers import get_providers
+        ort = import_ort()
 
         self._onnx_session = ort.InferenceSession(
             str(onnx_path),
@@ -94,9 +94,9 @@ class SpeechEmbedding:
     """
 
     def __init__(self, onnx_path: str | Path):
-        import onnxruntime as ort
+        from .._ort_providers import get_providers, import_ort
 
-        from .._ort_providers import get_providers
+        ort = import_ort()
 
         if not Path(onnx_path).exists():
             raise FileNotFoundError(

--- a/tests/test_ort_providers.py
+++ b/tests/test_ort_providers.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import builtins
 import logging
 
 import pytest
 
 from livekit.wakeword import _ort_providers
-from livekit.wakeword._ort_providers import get_providers
+from livekit.wakeword._ort_providers import get_providers, import_ort
 
 
 class TestEnvVarOverride:
@@ -113,6 +114,26 @@ class TestLogging:
         with caplog.at_level(logging.INFO, logger="livekit.wakeword._ort_providers"):
             get_providers()
         assert any("LIVEKIT_WAKEWORD_ORT_PROVIDERS" in r.message for r in caplog.records)
+
+
+class TestImportBackend:
+    def test_returns_module_when_installed(self) -> None:
+        import onnxruntime as ort
+
+        assert import_ort() is ort
+
+    def test_actionable_error_when_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No backend installed → a ModuleNotFoundError pointing at the cpu/gpu extras."""
+        real_import = builtins.__import__
+
+        def fake_import(name: str, *args: object, **kwargs: object) -> object:
+            if name == "onnxruntime":
+                raise ModuleNotFoundError("No module named 'onnxruntime'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        with pytest.raises(ModuleNotFoundError, match=r"\[cpu\]"):
+            import_ort()
 
 
 class TestCallSitesUseHelper:

--- a/tests/test_ort_providers.py
+++ b/tests/test_ort_providers.py
@@ -1,0 +1,139 @@
+"""Tests for runtime ONNX Runtime provider selection."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from livekit.wakeword import _ort_providers
+from livekit.wakeword._ort_providers import get_providers
+
+
+class TestEnvVarOverride:
+    def test_single_provider_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LIVEKIT_WAKEWORD_ORT_PROVIDERS", "CPUExecutionProvider")
+        assert get_providers() == ["CPUExecutionProvider"]
+
+    def test_multiple_providers_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(
+            "LIVEKIT_WAKEWORD_ORT_PROVIDERS",
+            "TensorrtExecutionProvider,CUDAExecutionProvider,CPUExecutionProvider",
+        )
+        assert get_providers() == [
+            "TensorrtExecutionProvider",
+            "CUDAExecutionProvider",
+            "CPUExecutionProvider",
+        ]
+
+    def test_whitespace_is_stripped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(
+            "LIVEKIT_WAKEWORD_ORT_PROVIDERS",
+            "  CUDAExecutionProvider , CPUExecutionProvider  ",
+        )
+        assert get_providers() == ["CUDAExecutionProvider", "CPUExecutionProvider"]
+
+    def test_empty_string_is_ignored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An empty env var must not override auto-detection."""
+        monkeypatch.setenv("LIVEKIT_WAKEWORD_ORT_PROVIDERS", "")
+        # Should fall through to auto-detect, which always yields at least CPU
+        assert "CPUExecutionProvider" in get_providers()
+
+    def test_trailing_comma_tolerated(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LIVEKIT_WAKEWORD_ORT_PROVIDERS", "CPUExecutionProvider,")
+        assert get_providers() == ["CPUExecutionProvider"]
+
+
+class TestAutoDetection:
+    def test_cpu_only_installation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Plain onnxruntime wheel: CPU is the only option."""
+        monkeypatch.delenv("LIVEKIT_WAKEWORD_ORT_PROVIDERS", raising=False)
+        monkeypatch.setattr(
+            _ort_providers,
+            "_DEFAULT_PREFERENCE",
+            ("CUDAExecutionProvider", "CPUExecutionProvider"),
+        )
+        import onnxruntime as ort
+
+        monkeypatch.setattr(ort, "get_available_providers", lambda: ["CPUExecutionProvider"])
+        assert get_providers() == ["CPUExecutionProvider"]
+
+    def test_gpu_installation_prefers_cuda(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """onnxruntime-gpu installed: CUDA first, CPU as fallback."""
+        monkeypatch.delenv("LIVEKIT_WAKEWORD_ORT_PROVIDERS", raising=False)
+        import onnxruntime as ort
+
+        monkeypatch.setattr(
+            ort,
+            "get_available_providers",
+            lambda: ["CUDAExecutionProvider", "CPUExecutionProvider"],
+        )
+        assert get_providers() == ["CUDAExecutionProvider", "CPUExecutionProvider"]
+
+    def test_ignores_unlisted_available_providers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Providers outside the default preference (e.g. Azure) are not auto-selected."""
+        monkeypatch.delenv("LIVEKIT_WAKEWORD_ORT_PROVIDERS", raising=False)
+        import onnxruntime as ort
+
+        monkeypatch.setattr(
+            ort,
+            "get_available_providers",
+            lambda: ["AzureExecutionProvider", "CPUExecutionProvider"],
+        )
+        result = get_providers()
+        assert result == ["CPUExecutionProvider"]
+        assert "AzureExecutionProvider" not in result
+
+    def test_falls_back_when_no_preferred_available(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If neither CUDA nor CPU is available, return whatever ORT offers."""
+        monkeypatch.delenv("LIVEKIT_WAKEWORD_ORT_PROVIDERS", raising=False)
+        import onnxruntime as ort
+
+        monkeypatch.setattr(
+            ort,
+            "get_available_providers",
+            lambda: ["CoreMLExecutionProvider"],
+        )
+        assert get_providers() == ["CoreMLExecutionProvider"]
+
+
+class TestLogging:
+    def test_logs_auto_selection(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.delenv("LIVEKIT_WAKEWORD_ORT_PROVIDERS", raising=False)
+        with caplog.at_level(logging.INFO, logger="livekit.wakeword._ort_providers"):
+            get_providers()
+        assert any("auto-selected" in r.message for r in caplog.records)
+
+    def test_logs_env_var_override(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setenv("LIVEKIT_WAKEWORD_ORT_PROVIDERS", "CPUExecutionProvider")
+        with caplog.at_level(logging.INFO, logger="livekit.wakeword._ort_providers"):
+            get_providers()
+        assert any("LIVEKIT_WAKEWORD_ORT_PROVIDERS" in r.message for r in caplog.records)
+
+
+class TestCallSitesUseHelper:
+    """Smoke check: the bundled feature extractor actually threads providers through."""
+
+    def test_mel_frontend_uses_helper(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Replacing get_providers() changes what MelSpectrogramFrontend passes to ORT."""
+        import onnxruntime as ort
+
+        from livekit.wakeword.models import feature_extractor
+        from livekit.wakeword.resources import get_mel_model_path
+
+        captured: dict[str, list[str]] = {}
+        real_init = ort.InferenceSession
+
+        def spy(path: str, *, providers: list[str], **kwargs: object) -> object:
+            captured["providers"] = providers
+            return real_init(path, providers=providers, **kwargs)
+
+        monkeypatch.setattr(ort, "InferenceSession", spy)
+        monkeypatch.setenv("LIVEKIT_WAKEWORD_ORT_PROVIDERS", "CPUExecutionProvider")
+
+        feature_extractor.MelSpectrogramFrontend(onnx_path=get_mel_model_path())
+        assert captured["providers"] == ["CPUExecutionProvider"]

--- a/uv.lock
+++ b/uv.lock
@@ -824,7 +824,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/e7/b47792cc2d01c7e1d37c32402182524774dadd2d26339bd224e0e913832e/cuda_bindings-12.9.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c912a3d9e6b6651853eed8eed96d6800d69c08e94052c292fec3f282c5a817c9", size = 12210593, upload-time = "2025-10-21T14:51:36.574Z" },
@@ -1749,6 +1749,9 @@ export = [
     { name = "onnxruntime" },
     { name = "onnxscript" },
 ]
+gpu = [
+    { name = "onnxruntime-gpu" },
+]
 listener = [
     { name = "pyaudio" },
 ]
@@ -1798,6 +1801,7 @@ requires-dist = [
     { name = "onnx", marker = "extra == 'export'", specifier = ">=1.15" },
     { name = "onnxruntime", specifier = ">=1.17" },
     { name = "onnxruntime", marker = "extra == 'export'", specifier = ">=1.17" },
+    { name = "onnxruntime-gpu", marker = "extra == 'gpu'", specifier = ">=1.17" },
     { name = "onnxscript", marker = "extra == 'export'", specifier = ">=0.6.2" },
     { name = "pronouncing", marker = "extra == 'train'", specifier = ">=0.2" },
     { name = "pyaudio", marker = "extra == 'listener'", specifier = ">=0.2.14" },
@@ -1816,7 +1820,7 @@ requires-dist = [
     { name = "voxcpm", marker = "extra == 'voxcpm'", specifier = ">=2.0.0" },
     { name = "webrtcvad", marker = "extra == 'train'", specifier = ">=2.0.10" },
 ]
-provides-extras = ["eval", "export", "listener", "train", "voxcpm"]
+provides-extras = ["eval", "export", "gpu", "listener", "train", "voxcpm"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2558,7 +2562,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -2569,7 +2573,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -2596,9 +2600,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -2609,7 +2613,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -2751,6 +2755,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/eb/6b154dd61cac410cacf27a9f53bbf49f4dbfe5b3982f3f5b0247c7bf7b78/onnxruntime-1.24.2-cp314-cp314-win_arm64.whl", hash = "sha256:6c501aaaaa674e689aaac501e26eb96aba908ebc067fe761fbcbed868bd694a6", size = 12491892, upload-time = "2026-02-19T17:14:54.584Z" },
     { url = "https://files.pythonhosted.org/packages/6f/84/14e5e804836476d3ef6ac07afe3ed6bdf01b69f8ef3ce6ae82c6c80b6d62/onnxruntime-1.24.2-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5360d3fd9c08ce17fff757759ce4b152852be14d597130f41174d8271f954630", size = 15036834, upload-time = "2026-02-19T17:13:33.65Z" },
     { url = "https://files.pythonhosted.org/packages/3a/27/ecdd3ae7d49d9f54820ededce2d88ddc3333b9ac9bb5f1d0d6aa3148c686/onnxruntime-1.24.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05a2792b5ef9278a89415a1f39d0a22192a872168257100503a5157165a38e7b", size = 17117770, upload-time = "2026-02-19T17:14:20.048Z" },
+]
+
+[[package]]
+name = "onnxruntime-gpu"
+version = "1.24.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/13/e080d758f2b60f71abe518c707135fb121d6a3019e0761ead89b5283ac3d/onnxruntime_gpu-1.24.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2a698659271c28220b3f56fe9b63f70eae3b3c36afa544201bf750b929a36dc", size = 252761835, upload-time = "2026-03-17T22:03:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/07/036825cbe30f91ea8574a18a759beccd0ea31b7b71e17f6a9ee9304b51d2/onnxruntime_gpu-1.24.4-cp311-cp311-win_amd64.whl", hash = "sha256:1a799a16e5f1ff4d6a9e5f72d750849ab0fe534da8d323ae4a5d8d8bb7daeca8", size = 207193563, upload-time = "2026-03-17T21:58:28.097Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2c/5b3fd4748cf7ed291eae541a37e426efc20ea04cb6e6a05768304ab0aa41/onnxruntime_gpu-1.24.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eb0e38f0c1ef3b76ae0081c8e51eed20dd8925aa916f0fc6f9b8b17d05610e99", size = 252765531, upload-time = "2026-03-17T22:03:57.528Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/86/70cecfdab1e963cc7f8c11e72040dfcd5cff85b1de2de74deba9611e0059/onnxruntime_gpu-1.24.4-cp312-cp312-win_amd64.whl", hash = "sha256:da5c1e327d8e119a831be2790e69f93cf6daab9145ed0aca7577f412a620f709", size = 207197978, upload-time = "2026-03-17T21:58:38.43Z" },
+    { url = "https://files.pythonhosted.org/packages/be/4e/56d11203d7a35e7d6a5ea735f5fecb8673537038c07323e8d3090a896547/onnxruntime_gpu-1.24.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bbdaa73f9055fb2a177425edbed651a1843a6239f9d5430e284f4e5f65440a33", size = 252763446, upload-time = "2026-03-17T22:04:09.515Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/bc/35f3a37226d7a28c84b8b456f52237ccd39eb7111114bcf9ac340178e1ec/onnxruntime_gpu-1.24.4-cp313-cp313-win_amd64.whl", hash = "sha256:6be8bf2048777c517fca33eb61e114969fa326619feaa789d8c75f24337ea762", size = 207198775, upload-time = "2026-03-17T21:58:48.768Z" },
+    { url = "https://files.pythonhosted.org/packages/37/83/0c851882051b38f245f44b4a51d6232b95b8cd5d334b2c1260f2d796834f/onnxruntime_gpu-1.24.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e4b348a078ced73fc577d21b83992fd2187edd10c233729c8d01b000b8543525", size = 252774594, upload-time = "2026-03-17T22:04:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/5b/82b27f766b64f97c9a98b772dc07b608e900bd2faafdfa176b86d20be7f8/onnxruntime_gpu-1.24.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:af9dd7ef92d94c75e5523cf070e180f3d8cdbb2fc007dcea97ba71b03e3b96d6", size = 252765395, upload-time = "2026-03-17T22:04:37.305Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/fa8c48e03790c979167d08164b34a8442c7074bca4c7253b4455497025de/onnxruntime_gpu-1.24.4-cp314-cp314-win_amd64.whl", hash = "sha256:4dde3d2f1039060c42b12fd446fc0da5b836cc65dceb4020ca60a04cffa1d90d", size = 209597109, upload-time = "2026-03-17T21:58:58.136Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/98/7707edefcecf69d6c45b83a83f13ac58257017b4eaf58772668d302f849f/onnxruntime_gpu-1.24.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:097c6f53e99ee35f21d0fdba76ca283b92465a0e364c6f0209cb9653c424e2a4", size = 252776951, upload-time = "2026-03-17T22:04:49.715Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,10 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'emscripten'",
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
+conflicts = [[
+    { package = "livekit-wakeword", extra = "cpu" },
+    { package = "livekit-wakeword", extra = "gpu" },
+]]
 
 [[package]]
 name = "addict"
@@ -142,7 +146,7 @@ version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "frozenlist" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -210,7 +214,7 @@ version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
@@ -315,8 +319,8 @@ name = "audioread"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "standard-aifc", marker = "python_full_version >= '3.13'" },
-    { name = "standard-sunau", marker = "python_full_version >= '3.13'" },
+    { name = "standard-aifc", marker = "python_full_version >= '3.13' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
+    { name = "standard-sunau", marker = "python_full_version >= '3.13' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/4a/874ecf9b472f998130c2b5e145dcdb9f6131e84786111489103b66772143/audioread-3.1.0.tar.gz", hash = "sha256:1c4ab2f2972764c896a8ac61ac53e261c8d29f0c6ccd652f84e18f08a4cab190", size = 20082, upload-time = "2025-10-26T19:44:13.484Z" }
 wheels = [
@@ -385,7 +389,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -528,7 +532,7 @@ name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
@@ -751,7 +755,7 @@ wheels = [
 
 [package.optional-dependencies]
 toml = [
-    { name = "tomli", marker = "python_full_version <= '3.11'" },
+    { name = "tomli", marker = "python_full_version <= '3.11' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
 ]
 
 [[package]]
@@ -765,7 +769,7 @@ name = "cryptography"
 version = "46.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
 wheels = [
@@ -824,15 +828,27 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/2b/ebcbb60aa6dba830474cd360c42e10282f7a343c0a1f58d24fbd3b7c2d77/cuda_bindings-12.9.4-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6a429dc6c13148ff1e27c44f40a3dd23203823e637b87fd0854205195988306", size = 11840604, upload-time = "2025-10-21T14:51:34.565Z" },
     { url = "https://files.pythonhosted.org/packages/45/e7/b47792cc2d01c7e1d37c32402182524774dadd2d26339bd224e0e913832e/cuda_bindings-12.9.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c912a3d9e6b6651853eed8eed96d6800d69c08e94052c292fec3f282c5a817c9", size = 12210593, upload-time = "2025-10-21T14:51:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/be/90d32049e06abcfba4b2e7df1dbcb5e16215c8852eef0cd8b25f38a66bd4/cuda_bindings-12.9.4-cp311-cp311-win_amd64.whl", hash = "sha256:443b0875916879c2e4c3722941e25e42d5ab9bcbf34c9e83404fb100fa1f6913", size = 11490933, upload-time = "2025-10-21T14:51:38.792Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c2/65bfd79292b8ff18be4dd7f7442cea37bcbc1a228c1886f1dea515c45b67/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:694ba35023846625ef471257e6b5a4bc8af690f961d197d77d34b1d1db393f56", size = 11760260, upload-time = "2025-10-21T14:51:40.79Z" },
     { url = "https://files.pythonhosted.org/packages/a9/c1/dabe88f52c3e3760d861401bb994df08f672ec893b8f7592dc91626adcf3/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8", size = 12151019, upload-time = "2025-10-21T14:51:43.167Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6b/9c1b1a6c01392bfdd758e9486f52a1a72bc8f49e98f9355774ef98b5fb4e/cuda_bindings-12.9.4-cp312-cp312-win_amd64.whl", hash = "sha256:696ca75d249ddf287d01b9a698b8e2d8a05046495a9c051ca15659dc52d17615", size = 11586961, upload-time = "2025-10-21T14:51:45.394Z" },
+    { url = "https://files.pythonhosted.org/packages/05/8b/b4b2d1c7775fa403b64333e720cfcfccef8dcb9cdeb99947061ca5a77628/cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf8bfaedc238f3b115d957d1fd6562b7e8435ba57f6d0e2f87d0e7149ccb2da5", size = 11570071, upload-time = "2025-10-21T14:51:47.472Z" },
     { url = "https://files.pythonhosted.org/packages/63/56/e465c31dc9111be3441a9ba7df1941fe98f4aa6e71e8788a3fb4534ce24d/cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:32bdc5a76906be4c61eb98f546a6786c5773a881f3b166486449b5d141e4a39f", size = 11906628, upload-time = "2025-10-21T14:51:49.905Z" },
+    { url = "https://files.pythonhosted.org/packages/05/d0/d0e4e2e047d8e899f023fa15ad5e9894ce951253f4c894f1cd68490fdb14/cuda_bindings-12.9.4-cp313-cp313-win_amd64.whl", hash = "sha256:a2e82c8985948f953c2be51df45c3fe11c812a928fca525154fb9503190b3e64", size = 11556719, upload-time = "2025-10-21T14:51:52.248Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/07/6aff13bc1e977e35aaa6b22f52b172e2890c608c6db22438cf7ed2bf43a6/cuda_bindings-12.9.4-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3adf4958dcf68ae7801a59b73fb00a8b37f8d0595060d66ceae111b1002de38d", size = 11566797, upload-time = "2025-10-21T14:51:54.581Z" },
     { url = "https://files.pythonhosted.org/packages/a3/84/1e6be415e37478070aeeee5884c2022713c1ecc735e6d82d744de0252eee/cuda_bindings-12.9.4-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56e0043c457a99ac473ddc926fe0dc4046694d99caef633e92601ab52cbe17eb", size = 11925991, upload-time = "2025-10-21T14:51:56.535Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/3c/972edfddb4ae8a9fccd3c3766ed47453b6f805b6026b32f10209dd4b8ad4/cuda_bindings-12.9.4-cp313-cp313t-win_amd64.whl", hash = "sha256:b32d8b685f0e66f5658bcf4601ef034e89fc2843582886f0a58784a4302da06c", size = 11894363, upload-time = "2025-10-21T14:51:58.633Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/b5/96a6696e20c4ffd2b327f54c7d0fde2259bdb998d045c25d5dedbbe30290/cuda_bindings-12.9.4-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f53a7f453d4b2643d8663d036bafe29b5ba89eb904c133180f295df6dc151e5", size = 11624530, upload-time = "2025-10-21T14:52:01.539Z" },
     { url = "https://files.pythonhosted.org/packages/d1/af/6dfd8f2ed90b1d4719bc053ff8940e494640fe4212dc3dd72f383e4992da/cuda_bindings-12.9.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8b72ee72a9cc1b531db31eebaaee5c69a8ec3500e32c6933f2d3b15297b53686", size = 11922703, upload-time = "2025-10-21T14:52:03.585Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/87/652796522cc1a7af559460e1ce59b642e05c1468b9c08522a9a096b4cf04/cuda_bindings-12.9.4-cp314-cp314-win_amd64.whl", hash = "sha256:53a10c71fdbdb743e0268d07964e5a996dd00b4e43831cbfce9804515d97d575", size = 11517716, upload-time = "2025-10-21T14:52:06.013Z" },
+    { url = "https://files.pythonhosted.org/packages/39/73/d2fc40c043bac699c3880bf88d3cebe9d88410cd043795382826c93a89f0/cuda_bindings-12.9.4-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20f2699d61d724de3eb3f3369d57e2b245f93085cab44fd37c3bea036cea1a6f", size = 11565056, upload-time = "2025-10-21T14:52:08.338Z" },
     { url = "https://files.pythonhosted.org/packages/6c/19/90ac264acc00f6df8a49378eedec9fd2db3061bf9263bf9f39fd3d8377c3/cuda_bindings-12.9.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d80bffc357df9988dca279734bc9674c3934a654cab10cadeed27ce17d8635ee", size = 11924658, upload-time = "2025-10-21T14:52:10.411Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/52/a30f46e822bfa6b4a659d1e8de8c4a4adf908ea075dac568b55362541bd8/cuda_bindings-12.9.4-cp314-cp314t-win_amd64.whl", hash = "sha256:53e11991a92ff6f26a0c8a98554cd5d6721c308a6b7bfb08bebac9201e039e43", size = 12055608, upload-time = "2025-10-21T14:52:12.335Z" },
 ]
 
 [[package]]
@@ -1179,7 +1195,7 @@ version = "6.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
     { name = "brotli" },
     { name = "fastapi" },
     { name = "gradio-client" },
@@ -1326,7 +1342,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
@@ -1650,8 +1666,8 @@ dependencies = [
     { name = "scipy" },
     { name = "soundfile" },
     { name = "soxr" },
-    { name = "standard-aifc", marker = "python_full_version >= '3.13'" },
-    { name = "standard-sunau", marker = "python_full_version >= '3.13'" },
+    { name = "standard-aifc", marker = "python_full_version >= '3.13' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
+    { name = "standard-sunau", marker = "python_full_version >= '3.13' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/64/36/360b5aafa0238e29758729e9486c6ed92a6f37fa403b7875e06c115cdf4a/librosa-0.11.0.tar.gz", hash = "sha256:f5ed951ca189b375bbe2e33b2abd7e040ceeee302b9bbaeeffdfddb8d0ace908", size = 327001, upload-time = "2025-03-11T15:09:54.884Z" }
@@ -1737,16 +1753,17 @@ name = "livekit-wakeword"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },
-    { name = "onnxruntime" },
 ]
 
 [package.optional-dependencies]
+cpu = [
+    { name = "onnxruntime" },
+]
 eval = [
     { name = "matplotlib" },
 ]
 export = [
     { name = "onnx" },
-    { name = "onnxruntime" },
     { name = "onnxscript" },
 ]
 gpu = [
@@ -1799,9 +1816,8 @@ requires-dist = [
     { name = "nltk", marker = "extra == 'train'", specifier = ">=3.8" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "onnx", marker = "extra == 'export'", specifier = ">=1.15" },
-    { name = "onnxruntime", specifier = ">=1.17" },
-    { name = "onnxruntime", marker = "extra == 'export'", specifier = ">=1.17" },
-    { name = "onnxruntime-gpu", marker = "extra == 'gpu'", specifier = ">=1.17" },
+    { name = "onnxruntime", marker = "extra == 'cpu'", specifier = ">=1.20" },
+    { name = "onnxruntime-gpu", marker = "extra == 'gpu'", specifier = ">=1.20" },
     { name = "onnxscript", marker = "extra == 'export'", specifier = ">=0.6.2" },
     { name = "pronouncing", marker = "extra == 'train'", specifier = ">=0.2" },
     { name = "pyaudio", marker = "extra == 'listener'", specifier = ">=0.2.14" },
@@ -1820,7 +1836,7 @@ requires-dist = [
     { name = "voxcpm", marker = "extra == 'voxcpm'", specifier = ">=2.0.0" },
     { name = "webrtcvad", marker = "extra == 'train'", specifier = ">=2.0.10" },
 ]
-provides-extras = ["eval", "export", "gpu", "listener", "train", "voxcpm"]
+provides-extras = ["cpu", "eval", "export", "gpu", "listener", "train", "voxcpm"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2281,7 +2297,7 @@ name = "mypy"
 version = "1.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
     { name = "mypy-extensions" },
     { name = "pathspec" },
     { name = "typing-extensions" },
@@ -2530,7 +2546,9 @@ name = "nvidia-cublas-cu12"
 version = "12.8.4.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/99/db44d685f0e257ff0e213ade1964fc459b4a690a73293220e98feb3307cf/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b86f6dd8935884615a0683b663891d43781b819ac4f2ba2b0c9604676af346d0", size = 590537124, upload-time = "2025-03-07T01:43:53.556Z" },
     { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
+    { url = "https://files.pythonhosted.org/packages/70/61/7d7b3c70186fb651d0fbd35b01dbfc8e755f69fd58f817f3d0f642df20c3/nvidia_cublas_cu12-12.8.4.1-py3-none-win_amd64.whl", hash = "sha256:47e9b82132fa8d2b4944e708049229601448aaad7e6f296f630f2d1a32de35af", size = 567544208, upload-time = "2025-03-07T01:53:30.535Z" },
 ]
 
 [[package]]
@@ -2538,7 +2556,9 @@ name = "nvidia-cuda-cupti-cu12"
 version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/1f/b3bd73445e5cb342727fd24fe1f7b748f690b460acadc27ea22f904502c8/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4412396548808ddfed3f17a467b104ba7751e6b58678a4b840675c56d21cf7ed", size = 9533318, upload-time = "2025-03-07T01:40:10.421Z" },
     { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
+    { url = "https://files.pythonhosted.org/packages/41/bc/83f5426095d93694ae39fe1311431b5d5a9bb82e48bf0dd8e19be2765942/nvidia_cuda_cupti_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:bb479dcdf7e6d4f8b0b01b115260399bf34154a1a2e9fe11c85c517d87efd98e", size = 7015759, upload-time = "2025-03-07T01:51:11.355Z" },
 ]
 
 [[package]]
@@ -2547,6 +2567,8 @@ version = "12.8.93"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d1/e50d0acaab360482034b84b6e27ee83c6738f7d32182b987f9c7a4e32962/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc1fec1e1637854b4c0a65fb9a8346b51dd9ee69e61ebaccc82058441f15bce8", size = 43106076, upload-time = "2025-03-07T01:41:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/45/51/52a3d84baa2136cc8df15500ad731d74d3a1114d4c123e043cb608d4a32b/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-win_amd64.whl", hash = "sha256:7a4b6b2904850fe78e0bd179c4b655c404d4bb799ef03ddc60804247099ae909", size = 73586838, upload-time = "2025-03-07T01:52:13.483Z" },
 ]
 
 [[package]]
@@ -2554,7 +2576,9 @@ name = "nvidia-cuda-runtime-cu12"
 version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/75/f865a3b236e4647605ea34cc450900854ba123834a5f1598e160b9530c3a/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:52bf7bbee900262ffefe5e9d5a2a69a30d97e2bc5bb6cc866688caa976966e3d", size = 965265, upload-time = "2025-03-07T01:39:43.533Z" },
     { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a5/a515b7600ad361ea14bfa13fb4d6687abf500adc270f19e89849c0590492/nvidia_cuda_runtime_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:c0c6027f01505bfed6c3b21ec546f69c687689aad5f1a377554bc6ca4aa993a8", size = 944318, upload-time = "2025-03-07T01:51:01.794Z" },
 ]
 
 [[package]]
@@ -2562,10 +2586,12 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/41/e79269ce215c857c935fd86bcfe91a451a584dfc27f1e068f568b9ad1ab7/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8", size = 705026878, upload-time = "2025-06-06T21:52:51.348Z" },
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/90/0bd6e586701b3a890fd38aa71c387dab4883d619d6e5ad912ccbd05bfd67/nvidia_cudnn_cu12-9.10.2.21-py3-none-win_amd64.whl", hash = "sha256:c6288de7d63e6cf62988f0923f96dc339cea362decb1bf5b3141883392a7d65e", size = 692992268, upload-time = "2025-06-06T21:55:18.114Z" },
 ]
 
 [[package]]
@@ -2573,10 +2599,12 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ec/ce1629f1e478bb5ccd208986b5f9e0316a78538dd6ab1d0484f012f8e2a1/nvidia_cufft_cu12-11.3.3.83-py3-none-win_amd64.whl", hash = "sha256:7a64a98ef2a7c47f905aaf8931b69a3a43f27c55530c698bb2ed7c75c0b42cb7", size = 192216559, upload-time = "2025-03-07T01:53:57.106Z" },
 ]
 
 [[package]]
@@ -2585,6 +2613,7 @@ version = "1.13.1.3"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f5/5607710447a6fe9fd9b3283956fceeee8a06cda1d2f56ce31371f595db2a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:4beb6d4cce47c1a0f1013d72e02b0994730359e17801d395bdcbf20cfb3bb00a", size = 1120705, upload-time = "2025-03-07T01:45:41.434Z" },
 ]
 
 [[package]]
@@ -2592,7 +2621,9 @@ name = "nvidia-curand-cu12"
 version = "10.3.9.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/5e/92aa15eca622a388b80fbf8375d4760738df6285b1e92c43d37390a33a9a/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:dfab99248034673b779bc6decafdc3404a8a6f502462201f2f31f11354204acd", size = 63625754, upload-time = "2025-03-07T01:46:10.735Z" },
     { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/75/70c05b2f3ed5be3bb30b7102b6eb78e100da4bbf6944fd6725c012831cab/nvidia_curand_cu12-10.3.9.90-py3-none-win_amd64.whl", hash = "sha256:f149a8ca457277da854f89cf282d6ef43176861926c7ac85b2a0fbd237c587ec", size = 62765309, upload-time = "2025-03-07T01:54:20.478Z" },
 ]
 
 [[package]]
@@ -2600,12 +2631,14 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c0/76ca8551b8a84146ffa189fec81c26d04adba4bc0dbe09cd6e6fd9b7de04/nvidia_cusolver_cu12-11.7.3.90-py3-none-win_amd64.whl", hash = "sha256:4a550db115fcabc4d495eb7d39ac8b58d4ab5d8e63274d3754df1c0ad6a22d34", size = 256720438, upload-time = "2025-03-07T01:54:39.898Z" },
 ]
 
 [[package]]
@@ -2613,10 +2646,12 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
+    { url = "https://files.pythonhosted.org/packages/62/07/f3b2ad63f8e3d257a599f422ae34eb565e70c41031aecefa3d18b62cabd1/nvidia_cusparse_cu12-12.5.8.93-py3-none-win_amd64.whl", hash = "sha256:9a33604331cb2cac199f2e7f5104dfbb8a5a898c367a53dfda9ff2acb6b6b4dd", size = 284937404, upload-time = "2025-03-07T01:55:07.742Z" },
 ]
 
 [[package]]
@@ -2624,7 +2659,9 @@ name = "nvidia-cusparselt-cu12"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/b9/598f6ff36faaece4b3c50d26f50e38661499ff34346f00e057760b35cc9d/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8878dce784d0fac90131b6817b607e803c36e629ba34dc5b433471382196b6a5", size = 283835557, upload-time = "2025-02-26T00:16:54.265Z" },
     { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d8/a6b0d0d0c2435e9310f3e2bb0d9c9dd4c33daef86aa5f30b3681defd37ea/nvidia_cusparselt_cu12-0.7.1-py3-none-win_amd64.whl", hash = "sha256:f67fbb5831940ec829c9117b7f33807db9f9678dc2a617fbe781cac17b4e1075", size = 271020911, upload-time = "2025-02-26T00:14:47.204Z" },
 ]
 
 [[package]]
@@ -2632,6 +2669,7 @@ name = "nvidia-nccl-cu12"
 version = "2.27.5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/1c/857979db0ef194ca5e21478a0612bcdbbe59458d7694361882279947b349/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:31432ad4d1fb1004eb0c56203dc9bc2178a1ba69d1d9e02d64a6938ab5e40e7a", size = 322400625, upload-time = "2025-06-26T04:11:04.496Z" },
     { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229, upload-time = "2025-06-26T04:11:28.385Z" },
 ]
 
@@ -2641,6 +2679,8 @@ version = "12.8.93"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a2/8cee5da30d13430e87bf99bb33455d2724d0a4a9cb5d7926d80ccb96d008/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:adccd7161ace7261e01bb91e44e88da350895c270d23f744f0820c818b7229e7", size = 38386204, upload-time = "2025-03-07T01:49:43.612Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/d7/34f02dad2e30c31b10a51f6b04e025e5dd60e5f936af9045a9b858a05383/nvidia_nvjitlink_cu12-12.8.93-py3-none-win_amd64.whl", hash = "sha256:bd93fbeeee850917903583587f4fc3a4eafa022e34572251368238ab5e6bd67f", size = 268553710, upload-time = "2025-03-07T01:56:24.13Z" },
 ]
 
 [[package]]
@@ -2648,6 +2688,7 @@ name = "nvidia-nvshmem-cu12"
 version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/6a/03aa43cc9bd3ad91553a88b5f6fb25ed6a3752ae86ce2180221962bc2aa5/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0b48363fc6964dede448029434c6abed6c5e37f823cb43c3bcde7ecfc0457e15", size = 138936938, upload-time = "2025-09-06T00:32:05.589Z" },
     { url = "https://files.pythonhosted.org/packages/b5/09/6ea3ea725f82e1e76684f0708bbedd871fc96da89945adeba65c3835a64c/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd", size = 139103095, upload-time = "2025-09-06T00:32:31.266Z" },
 ]
 
@@ -2656,7 +2697,9 @@ name = "nvidia-nvtx-cu12"
 version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/c0/1b303feea90d296f6176f32a2a70b5ef230f9bdeb3a72bddb0dc922dc137/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615", size = 91161, upload-time = "2025-03-07T01:42:23.922Z" },
     { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/99/4c9c0c329bf9fc125008c3b54c7c94c0023518d06fc025ae36431375e1fe/nvidia_nvtx_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:619c8304aedc69f02ea82dd244541a83c3d9d40993381b3b590f1adaed3db41e", size = 56492, upload-time = "2025-03-07T01:52:24.69Z" },
 ]
 
 [[package]]
@@ -2896,7 +2939,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
 wheels = [
@@ -3514,7 +3557,7 @@ name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
@@ -3531,7 +3574,7 @@ version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
@@ -4197,8 +4240,8 @@ name = "standard-aifc"
 version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
-    { name = "standard-chunk", marker = "python_full_version >= '3.13'" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
+    { name = "standard-chunk", marker = "python_full_version >= '3.13' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/53/6050dc3dde1671eb3db592c13b55a8005e5040131f7509cef0215212cb84/standard_aifc-3.13.0.tar.gz", hash = "sha256:64e249c7cb4b3daf2fdba4e95721f811bde8bdfc43ad9f936589b7bb2fae2e43", size = 15240, upload-time = "2024-10-30T16:01:31.772Z" }
 wheels = [
@@ -4219,7 +4262,7 @@ name = "standard-sunau"
 version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/e3/ce8d38cb2d70e05ffeddc28bb09bad77cfef979eb0a299c9117f7ed4e6a9/standard_sunau-3.13.0.tar.gz", hash = "sha256:b319a1ac95a09a2378a8442f403c66f4fd4b36616d6df6ae82b8e536ee790908", size = 9368, upload-time = "2024-10-30T16:01:41.626Z" }
 wheels = [
@@ -4232,7 +4275,7 @@ version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
@@ -4381,29 +4424,29 @@ name = "torch"
 version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "cuda-bindings", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu') or (sys_platform != 'linux' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setuptools", marker = "python_full_version >= '3.12'" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu') or (sys_platform != 'linux' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu') or (sys_platform != 'linux' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu') or (sys_platform != 'linux' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu') or (sys_platform != 'linux' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
+    { name = "nvidia-cudnn-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu') or (sys_platform != 'linux' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
+    { name = "nvidia-cufft-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu') or (sys_platform != 'linux' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
+    { name = "nvidia-cufile-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu') or (sys_platform != 'linux' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
+    { name = "nvidia-curand-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu') or (sys_platform != 'linux' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
+    { name = "nvidia-cusolver-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu') or (sys_platform != 'linux' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
+    { name = "nvidia-cusparse-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu') or (sys_platform != 'linux' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
+    { name = "nvidia-cusparselt-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu') or (sys_platform != 'linux' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
+    { name = "nvidia-nccl-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu') or (sys_platform != 'linux' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu') or (sys_platform != 'linux' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
+    { name = "nvidia-nvshmem-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu') or (sys_platform != 'linux' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
+    { name = "nvidia-nvtx-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu') or (sys_platform != 'linux' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
+    { name = "setuptools", marker = "python_full_version >= '3.12' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
     { name = "sympy" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "triton", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu') or (sys_platform != 'linux' and extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
     { name = "typing-extensions" },
 ]
 wheels = [
@@ -4547,7 +4590,7 @@ name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-16-livekit-wakeword-cpu' and extra == 'extra-16-livekit-wakeword-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
@@ -4579,11 +4622,17 @@ name = "triton"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/2c/96f92f3c60387e14cc45aed49487f3486f89ea27106c1b1376913c62abe4/triton-3.6.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49df5ef37379c0c2b5c0012286f80174fcf0e073e5ade1ca9a86c36814553651", size = 176081190, upload-time = "2026-01-20T16:16:00.523Z" },
     { url = "https://files.pythonhosted.org/packages/e0/12/b05ba554d2c623bffa59922b94b0775673de251f468a9609bc9e45de95e9/triton-3.6.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8e323d608e3a9bfcc2d9efcc90ceefb764a82b99dea12a86d643c72539ad5d3", size = 188214640, upload-time = "2026-01-20T16:00:35.869Z" },
+    { url = "https://files.pythonhosted.org/packages/17/5d/08201db32823bdf77a0e2b9039540080b2e5c23a20706ddba942924ebcd6/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:374f52c11a711fd062b4bfbb201fd9ac0a5febd28a96fb41b4a0f51dde3157f4", size = 176128243, upload-time = "2026-01-20T16:16:07.857Z" },
     { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/12/34d71b350e89a204c2c7777a9bba0dcf2f19a5bfdd70b57c4dbc5ffd7154/triton-3.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448e02fe6dc898e9e5aa89cf0ee5c371e99df5aa5e8ad976a80b93334f3494fd", size = 176133521, upload-time = "2026-01-20T16:16:13.321Z" },
     { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4e/41b0c8033b503fd3cfcd12392cdd256945026a91ff02452bef40ec34bee7/triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1722e172d34e32abc3eb7711d0025bb69d7959ebea84e3b7f7a341cd7ed694d6", size = 176276087, upload-time = "2026-01-20T16:16:18.989Z" },
     { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
+    { url = "https://files.pythonhosted.org/packages/49/55/5ecf0dcaa0f2fbbd4420f7ef227ee3cb172e91e5fede9d0ecaddc43363b4/triton-3.6.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5523241e7d1abca00f1d240949eebdd7c673b005edbbce0aca95b8191f1d43", size = 176138577, upload-time = "2026-01-20T16:16:25.426Z" },
     { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
+    { url = "https://files.pythonhosted.org/packages/48/db/56ee649cab5eaff4757541325aca81f52d02d4a7cd3506776cad2451e060/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d", size = 176274804, upload-time = "2026-01-20T16:16:31.528Z" },
     { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
 ]
 


### PR DESCRIPTION
## The bug

Every `ort.InferenceSession` in the project is created with `providers=["CPUExecutionProvider"]` hardcoded, in four places:

- `src/livekit/wakeword/models/feature_extractor.py:42-44` (Mel)
- `src/livekit/wakeword/models/feature_extractor.py:101-103` (Embedding)
- `src/livekit/wakeword/inference/model.py:87-89` (classifier)
- `src/livekit/wakeword/eval/evaluate.py:197` (eval)

Even if a user installs `onnxruntime-gpu` on a GPU pod, CUDA is never selected. The Swift package already supports pluggable execution providers (`ExecutionProvider.coreML`), so this gap is Python-specific.

## Impact

Feature extraction during `augment` is the most ORT-heavy stage — roughly 17 model calls per 2 s clip (1 mel + 16 sliding embedding windows). On an RTX 3090 pod this runs on CPU at ~3 clips/sec. A production config (~150k augmented clips across 6 splits × 2 rounds) takes ~14 hours of CPU time; with CUDA active, the same workload finished in ~13 minutes on the same pod.

The bug also affects `WakeWordModel` (the listener) and `run_eval`, both of which silently stay on CPU even when the host has `onnxruntime-gpu` installed.

## The fix

New helper `src/livekit/wakeword/_ort_providers.py` with a single function:

```python
def get_providers() -> list[str]:
    # 1. LIVEKIT_WAKEWORD_ORT_PROVIDERS env var (comma-separated) wins if set
    # 2. Otherwise intersect ort.get_available_providers() with
    #    (\"CUDAExecutionProvider\", \"CPUExecutionProvider\") — CUDA first, CPU fallback
    # 3. If neither is available, fall through to whatever ORT reports
```

All four call sites now use it. **Behaviour on CPU-only installs is unchanged** (plain `onnxruntime` reports only `CPUExecutionProvider`).

The env var escape hatch covers:
- Forcing CPU on GPU hosts for reproducibility
- Opting into CoreML / DirectML / ROCm / TensorRT providers without plumbing a config field

Design decisions:
- **Helper, not duplicated call-site logic** — four copies of provider selection would drift.
- **Env var, not config field or constructor arg** — a config field only helps YAML-driven training, not library consumers of `WakeWordModel`; a constructor arg would thread through multiple public APIs. Env var works everywhere with zero surface change.
- **Default preference is CUDA / CPU only** — CoreML / DirectML / ROCm / TensorRT are exotic enough to warrant explicit opt-in via the env var.
- **No warning when CPU is selected on a GPU host** — can't cheaply detect \"GPU hardware present\" from Python without importing torch; users who suspect slowness can check the INFO log for the selected provider list.

## Packaging

Adds an optional `gpu` extra in `pyproject.toml`:

```toml
gpu = [\"onnxruntime-gpu>=1.17\"]
```

README gets a new \"GPU acceleration\" subsection documenting the switch:

```bash
pip uninstall -y onnxruntime
pip install livekit-wakeword[train,eval,export,gpu]
```

The uninstall step is required because `onnxruntime` and `onnxruntime-gpu` share the Python module name — pip cannot keep them side-by-side. The README also points at ONNX Runtime's GPU compatibility matrix since the `onnxruntime-gpu` wheel bundles specific CUDA toolkit versions.

## What's in this PR

| File | Change |
|---|---|
| `src/livekit/wakeword/_ort_providers.py` | **New**: `get_providers()` helper |
| `src/livekit/wakeword/models/feature_extractor.py` | Use helper in `MelSpectrogramFrontend` + `SpeechEmbedding` |
| `src/livekit/wakeword/inference/model.py` | Use helper in `WakeWordModel.load_model` |
| `src/livekit/wakeword/eval/evaluate.py` | Use helper in `run_eval` |
| `pyproject.toml` | New `gpu` optional extra |
| `README.md` | GPU acceleration subsection in the training install flow |
| `tests/test_ort_providers.py` | **New**: 12 tests — env-var override parsing, auto-detection, filtering, logging, real-call-site smoke on `MelSpectrogramFrontend` |
| `uv.lock` | Regenerated for the new extra |

## Out of scope (deliberately — these are follow-ups)

- **Cross-clip batching in `run_extraction`**: `features.py` processes one clip at a time. Even on GPU this leaves throughput on the table; a batched path would give another large speedup. Worth its own PR — touches the extraction loop, not provider selection.
- **Splitting `augment` into `augment` + `extract` CLI commands**: right now `run_augmentation` deletes all `*_rN.wav` files at the top, so if feature extraction fails the user re-runs and loses the augmented clips. A `--no-clean` flag and/or a separate `extract` command is a UX concern, not a provider concern.

## Verification

```
uv run ruff check src/livekit/wakeword/_ort_providers.py <touched files>  # clean
uv run ruff format --check <touched files>                                 # clean
uv run mypy src/livekit/wakeword/                                          # same 1 pre-existing error as main
uv run pytest tests/                                                       # 72 passed (60 existing + 12 new)
```

Reproduction of the original bug:

```bash
livekit-wakeword generate configs/prod.yaml
livekit-wakeword augment configs/prod.yaml
# Feature extraction sub-stage runs at ~3 cps on a GPU pod. nvidia-smi shows 0% util.
```

After this PR, with `livekit-wakeword[train,eval,export,gpu]` installed (and `onnxruntime` uninstalled), the same workload saturates the GPU — measured ~200 cps on RTX 3090.