### PR TITLE
Add root Package.swift forwarder for Xcode SPM-by-URL

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version:5.9
+//
+// Root forwarder so Xcode's "Add Package Dependencies → URL" flow works
+// against this repo. Upstream livekit/livekit-wakeword keeps the actual
+// Swift package at swift/Package.swift because the repo also contains
+// Python and Rust crates; Xcode only looks at the repo root, so without
+// this file the remote SPM resolve fails with "Package.swift doesn't
+// exist in file system."
+//
+// The package code, sources, and resources still live under swift/ —
+// this manifest just points the SwiftPM target at them.
+import PackageDescription
+
+let package = Package(
+    name: "LiveKitWakeWord",
+    platforms: [.iOS(.v16), .macOS(.v14)],
+    products: [
+        .library(name: "LiveKitWakeWord", targets: ["LiveKitWakeWord"]),
+    ],
+    dependencies: [
+        .package(
+            url: "https://github.com/microsoft/onnxruntime-swift-package-manager",
+            from: "1.20.0"
+        ),
+    ],
+    targets: [
+        .target(
+            name: "LiveKitWakeWord",
+            dependencies: [
+                .product(name: "onnxruntime", package: "onnxruntime-swift-package-manager"),
+            ],
+            path: "swift/Sources/LiveKitWakeWord",
+            resources: [
+                .copy("Resources/melspectrogram.onnx"),
+                .copy("Resources/embedding_model.onnx"),
+            ]
+        ),
+    ]
+)


### PR DESCRIPTION
## Problem

The Swift package lives at `swift/Package.swift` because this repo also contains Python and Rust crates. Xcode's "File → Add Package Dependencies → URL" flow only checks the repo root, so a remote SPM resolve against this repo's URL currently fails with:

```
the package manifest at '/Package.swift' cannot be accessed (/Package.swift doesn't exist in file system)
```

Users who want to add LiveKitWakeWord to their iOS app via the standard Xcode UI hit this. The workaround (fork the repo, add a root manifest) is awkward enough that many will just give up and use a different package.

## Fix

Add a thin forwarder `Package.swift` at the repo root that:

- Declares the same `LiveKitWakeWord` product
- Pulls in the same ONNX Runtime dependency
- Points the target at `swift/Sources/LiveKitWakeWord/` with resources relative to that

No source changes. Existing `swift/Package.swift` and the local-path-based `examples/ios_wakeword` setup keep working untouched — having two manifests in the same repo is legal SwiftPM (the local-path resolver picks `swift/Package.swift` because that's the path it's told to use; the remote-URL resolver picks the root one because that's what Xcode looks for).

## Test

```bash
$ swift package describe --type json | jq -r '.products[].name'
LiveKitWakeWord
```

And via Xcode 15 → Add Package Dependencies → `https://github.com/<your-fork>/livekit-wakeword` → branch `main` → product `LiveKitWakeWord` resolves and `import LiveKitWakeWord` works.

(Verified against a fork of this repo + a working sushik-ios integration on iOS 26.)